### PR TITLE
APIからデータ取得 : 総合/男性/女性の切り替え実装

### DIFF
--- a/rakuten_ranking_app.xcodeproj/project.pbxproj
+++ b/rakuten_ranking_app.xcodeproj/project.pbxproj
@@ -23,6 +23,12 @@
 		6D6782132BEC69DB00423201 /* RankingForAllViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D6782122BEC69DB00423201 /* RankingForAllViewController.swift */; };
 		6D6782152BEC69FD00423201 /* RankingForMaleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D6782142BEC69FD00423201 /* RankingForMaleViewController.swift */; };
 		6D6782172BEC6A0900423201 /* RankingForFemaleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D6782162BEC6A0900423201 /* RankingForFemaleViewController.swift */; };
+		6D6782562BF2107000423201 /* APIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D6782552BF2107000423201 /* APIClient.swift */; };
+		6D6782592BF2109900423201 /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = 6D6782582BF2109900423201 /* Alamofire */; };
+		6D67825B2BF2109900423201 /* AlamofireDynamic in Frameworks */ = {isa = PBXBuildFile; productRef = 6D67825A2BF2109900423201 /* AlamofireDynamic */; };
+		6D67825D2BF2111100423201 /* RankingAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D67825C2BF2111100423201 /* RankingAPI.swift */; };
+		6D6782602BF2117400423201 /* RankingModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D67825F2BF2117400423201 /* RankingModel.swift */; };
+		6D6782632BF211D100423201 /* Ranking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D6782622BF211D100423201 /* Ranking.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -63,6 +69,10 @@
 		6D6782122BEC69DB00423201 /* RankingForAllViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RankingForAllViewController.swift; sourceTree = "<group>"; };
 		6D6782142BEC69FD00423201 /* RankingForMaleViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RankingForMaleViewController.swift; sourceTree = "<group>"; };
 		6D6782162BEC6A0900423201 /* RankingForFemaleViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RankingForFemaleViewController.swift; sourceTree = "<group>"; };
+		6D6782552BF2107000423201 /* APIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClient.swift; sourceTree = "<group>"; };
+		6D67825C2BF2111100423201 /* RankingAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RankingAPI.swift; sourceTree = "<group>"; };
+		6D67825F2BF2117400423201 /* RankingModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RankingModel.swift; sourceTree = "<group>"; };
+		6D6782622BF211D100423201 /* Ranking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Ranking.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -70,6 +80,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6D6782592BF2109900423201 /* Alamofire in Frameworks */,
+				6D67825B2BF2109900423201 /* AlamofireDynamic in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -160,6 +172,9 @@
 		6D6781EA2BEA2CAD00423201 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				6D6782612BF211B400423201 /* JSONExport */,
+				6D67825E2BF2116200423201 /* Ranking */,
+				6D6782542BF2100C00423201 /* API */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -170,6 +185,31 @@
 				6D67820E2BEB2C3D00423201 /* TabBarController.swift */,
 			);
 			path = Controllers;
+			sourceTree = "<group>";
+		};
+		6D6782542BF2100C00423201 /* API */ = {
+			isa = PBXGroup;
+			children = (
+				6D6782552BF2107000423201 /* APIClient.swift */,
+				6D67825C2BF2111100423201 /* RankingAPI.swift */,
+			);
+			path = API;
+			sourceTree = "<group>";
+		};
+		6D67825E2BF2116200423201 /* Ranking */ = {
+			isa = PBXGroup;
+			children = (
+				6D67825F2BF2117400423201 /* RankingModel.swift */,
+			);
+			path = Ranking;
+			sourceTree = "<group>";
+		};
+		6D6782612BF211B400423201 /* JSONExport */ = {
+			isa = PBXGroup;
+			children = (
+				6D6782622BF211D100423201 /* Ranking.swift */,
+			);
+			path = JSONExport;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -188,6 +228,10 @@
 			dependencies = (
 			);
 			name = rakuten_ranking_app;
+			packageProductDependencies = (
+				6D6782582BF2109900423201 /* Alamofire */,
+				6D67825A2BF2109900423201 /* AlamofireDynamic */,
+			);
 			productName = rakuten_ranking_app;
 			productReference = 6D6781B62BEA268000423201 /* rakuten_ranking_app.app */;
 			productType = "com.apple.product-type.application";
@@ -260,6 +304,9 @@
 				Base,
 			);
 			mainGroup = 6D6781AD2BEA268000423201;
+			packageReferences = (
+				6D6782572BF2109900423201 /* XCRemoteSwiftPackageReference "Alamofire" */,
+			);
 			productRefGroup = 6D6781B72BEA268000423201 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -307,12 +354,16 @@
 				6D67820B2BEB290900423201 /* SearchViewController.swift in Sources */,
 				6D6782092BEB28FC00423201 /* RankingViewController.swift in Sources */,
 				6D67820F2BEB2C3D00423201 /* TabBarController.swift in Sources */,
+				6D6782602BF2117400423201 /* RankingModel.swift in Sources */,
 				6D6781BA2BEA268000423201 /* AppDelegate.swift in Sources */,
+				6D6782562BF2107000423201 /* APIClient.swift in Sources */,
 				6D6782132BEC69DB00423201 /* RankingForAllViewController.swift in Sources */,
 				6D6781BC2BEA268000423201 /* SceneDelegate.swift in Sources */,
 				6D6782172BEC6A0900423201 /* RankingForFemaleViewController.swift in Sources */,
+				6D6782632BF211D100423201 /* Ranking.swift in Sources */,
 				6D6782112BEC61AD00423201 /* RankingPageViewController.swift in Sources */,
 				6D6782152BEC69FD00423201 /* RankingForMaleViewController.swift in Sources */,
+				6D67825D2BF2111100423201 /* RankingAPI.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -653,6 +704,30 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		6D6782572BF2109900423201 /* XCRemoteSwiftPackageReference "Alamofire" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/Alamofire/Alamofire";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 5.9.1;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		6D6782582BF2109900423201 /* Alamofire */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 6D6782572BF2109900423201 /* XCRemoteSwiftPackageReference "Alamofire" */;
+			productName = Alamofire;
+		};
+		6D67825A2BF2109900423201 /* AlamofireDynamic */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 6D6782572BF2109900423201 /* XCRemoteSwiftPackageReference "Alamofire" */;
+			productName = AlamofireDynamic;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 6D6781AE2BEA268000423201 /* Project object */;
 }

--- a/rakuten_ranking_app.xcodeproj/project.pbxproj
+++ b/rakuten_ranking_app.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		6D67825D2BF2111100423201 /* RankingAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D67825C2BF2111100423201 /* RankingAPI.swift */; };
 		6D6782602BF2117400423201 /* RankingModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D67825F2BF2117400423201 /* RankingModel.swift */; };
 		6D6782632BF211D100423201 /* Ranking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D6782622BF211D100423201 /* Ranking.swift */; };
+		6D6782672BF4A6CF00423201 /* constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D6782662BF4A6CF00423201 /* constants.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -73,6 +74,7 @@
 		6D67825C2BF2111100423201 /* RankingAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RankingAPI.swift; sourceTree = "<group>"; };
 		6D67825F2BF2117400423201 /* RankingModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RankingModel.swift; sourceTree = "<group>"; };
 		6D6782622BF211D100423201 /* Ranking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Ranking.swift; sourceTree = "<group>"; };
+		6D6782662BF4A6CF00423201 /* constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = constants.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -134,6 +136,7 @@
 				6D6781C22BEA268000423201 /* Assets.xcassets */,
 				6D6781C42BEA268000423201 /* LaunchScreen.storyboard */,
 				6D6781C72BEA268000423201 /* Info.plist */,
+				6D6782662BF4A6CF00423201 /* constants.swift */,
 			);
 			path = rakuten_ranking_app;
 			sourceTree = "<group>";
@@ -357,6 +360,7 @@
 				6D6782602BF2117400423201 /* RankingModel.swift in Sources */,
 				6D6781BA2BEA268000423201 /* AppDelegate.swift in Sources */,
 				6D6782562BF2107000423201 /* APIClient.swift in Sources */,
+				6D6782672BF4A6CF00423201 /* constants.swift in Sources */,
 				6D6782132BEC69DB00423201 /* RankingForAllViewController.swift in Sources */,
 				6D6781BC2BEA268000423201 /* SceneDelegate.swift in Sources */,
 				6D6782172BEC6A0900423201 /* RankingForFemaleViewController.swift in Sources */,

--- a/rakuten_ranking_app.xcodeproj/project.pbxproj
+++ b/rakuten_ranking_app.xcodeproj/project.pbxproj
@@ -29,7 +29,7 @@
 		6D67825D2BF2111100423201 /* RankingAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D67825C2BF2111100423201 /* RankingAPI.swift */; };
 		6D6782602BF2117400423201 /* RankingModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D67825F2BF2117400423201 /* RankingModel.swift */; };
 		6D6782632BF211D100423201 /* Ranking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D6782622BF211D100423201 /* Ranking.swift */; };
-		6D6782672BF4A6CF00423201 /* constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D6782662BF4A6CF00423201 /* constants.swift */; };
+		6D6782672BF4A6CF00423201 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D6782662BF4A6CF00423201 /* Constants.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -74,7 +74,7 @@
 		6D67825C2BF2111100423201 /* RankingAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RankingAPI.swift; sourceTree = "<group>"; };
 		6D67825F2BF2117400423201 /* RankingModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RankingModel.swift; sourceTree = "<group>"; };
 		6D6782622BF211D100423201 /* Ranking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Ranking.swift; sourceTree = "<group>"; };
-		6D6782662BF4A6CF00423201 /* constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = constants.swift; sourceTree = "<group>"; };
+		6D6782662BF4A6CF00423201 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -136,7 +136,7 @@
 				6D6781C22BEA268000423201 /* Assets.xcassets */,
 				6D6781C42BEA268000423201 /* LaunchScreen.storyboard */,
 				6D6781C72BEA268000423201 /* Info.plist */,
-				6D6782662BF4A6CF00423201 /* constants.swift */,
+				6D6782662BF4A6CF00423201 /* Constants.swift */,
 			);
 			path = rakuten_ranking_app;
 			sourceTree = "<group>";
@@ -360,7 +360,7 @@
 				6D6782602BF2117400423201 /* RankingModel.swift in Sources */,
 				6D6781BA2BEA268000423201 /* AppDelegate.swift in Sources */,
 				6D6782562BF2107000423201 /* APIClient.swift in Sources */,
-				6D6782672BF4A6CF00423201 /* constants.swift in Sources */,
+				6D6782672BF4A6CF00423201 /* Constants.swift in Sources */,
 				6D6782132BEC69DB00423201 /* RankingForAllViewController.swift in Sources */,
 				6D6781BC2BEA268000423201 /* SceneDelegate.swift in Sources */,
 				6D6782172BEC6A0900423201 /* RankingForFemaleViewController.swift in Sources */,

--- a/rakuten_ranking_app.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/rakuten_ranking_app.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "11b78eba97192d19796cff581fdf69b3e65b441188b1448a1b67e5d7b825a354",
+  "pins" : [
+    {
+      "identity" : "alamofire",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Alamofire/Alamofire",
+      "state" : {
+        "revision" : "f455c2975872ccd2d9c81594c658af65716e9b9a",
+        "version" : "5.9.1"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/rakuten_ranking_app/Constants.swift
+++ b/rakuten_ranking_app/Constants.swift
@@ -7,11 +7,17 @@
 
 import Foundation
 
-struct Const {
+struct NetworkConst {
     static let baseURL = "https://app.rakuten.co.jp/services/api/"
     static let applicationId = "1054850339030324271"
+}
+
+struct APIPathConst {
     static let rankingAPIUrlPath = "IchibaItem/Ranking/20220601"
-    static let notificationName = "ranking"
+}
+
+struct NotificationConst {
+    static let rankingNotificationName = "ranking"
 }
 
 

--- a/rakuten_ranking_app/Constants.swift
+++ b/rakuten_ranking_app/Constants.swift
@@ -7,12 +7,11 @@
 
 import Foundation
 
-//ここで固定値を定義し渡す
-struct const {
+struct Const {
     static let baseURL = "https://app.rakuten.co.jp/services/api/"
     static let applicationId = "1054850339030324271"
-    //APIリクエストURLで?applicationId が2回出現している　↓修正
-    static let urlPath = "IchibaItem/Ranking/20220601"
+    static let rankingAPIUrlPath = "IchibaItem/Ranking/20220601"
+    static let notificationName = "ranking"
 }
 
 

--- a/rakuten_ranking_app/Models/API/APIClient.swift
+++ b/rakuten_ranking_app/Models/API/APIClient.swift
@@ -63,7 +63,7 @@ extension Request {
     }
 
     func makeRequest() -> URLRequest {
-        let baseURL = Const.baseURL
+        let baseURL = NetworkConst.baseURL
         guard let baseURL = URL(string: baseURL) else {
             fatalError("無効なbaseURL")
         }
@@ -72,7 +72,7 @@ extension Request {
         urlRequest.httpMethod = method.rawValue
         
         var parameters = self.parameters
-        parameters.updateValue(Const.applicationId, forKey: "applicationId")
+        parameters.updateValue(NetworkConst.applicationId, forKey: "applicationId")
         var urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false)!
         var queryItems = [URLQueryItem]()
         for (key, value) in parameters {

--- a/rakuten_ranking_app/Models/API/APIClient.swift
+++ b/rakuten_ranking_app/Models/API/APIClient.swift
@@ -1,0 +1,104 @@
+//
+//  APIClient.swift
+//  rakuten_ranking_app
+//
+//  Created by 櫻田龍之助 on 2024/05/13.
+//
+
+import Foundation
+import Alamofire
+
+public enum APIError: Error {
+    case network
+    case server
+    case invalidJSON
+}
+
+extension APIError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .network:
+            return "ネットワークの接続状態を確認してください。"
+        case .server:
+            return "サーバーと通信できません。"
+        case .invalidJSON:
+            return "JSONパース失敗。"
+        }
+    }
+}
+
+public enum HTTPMethod: String {
+    case post
+    case get
+}
+
+public protocol Request {
+    var baseURL: URL { get }
+    var method: HTTPMethod { get }
+    var path: String { get }
+    var headerFields: [String: String] { get }
+    var parameter: [String: Any] { get }
+    var timeout: TimeInterval { get }
+    var contentType: String { get }
+    var accept: String { get }
+    
+    func makeRequest() -> URLRequest
+}
+
+public extension Request {
+    var headerFields: [String: String] {
+        return [:]
+    }
+
+    var timeout: TimeInterval {
+        return 65
+    }
+
+    var contentType: String {
+        return ""
+    }
+
+    var accept: String {
+        return ""
+    }
+
+    func makeRequest() -> URLRequest {
+        let url = path.isEmpty ? baseURL : baseURL.appendingPathComponent(path)
+        var urlRequest = URLRequest(url: url, timeoutInterval: timeout)
+        urlRequest.httpMethod = method.rawValue
+        if !parameter.isEmpty {
+            if let request = try? URLEncoding.default.encode(urlRequest, with: parameter) {
+                urlRequest = request
+            }
+        }
+        headerFields.forEach { key, value in
+            urlRequest.setValue(value, forHTTPHeaderField: key)
+        }
+        if case .post = method {
+            urlRequest.setValue(contentType, forHTTPHeaderField: "Content-Type")
+        }
+        urlRequest.setValue(accept, forHTTPHeaderField: "Accept")
+        return urlRequest
+    }
+}
+
+public protocol APIClient {
+    func request(_ request: Request, completion: @escaping (Result<Data, APIError>) -> Void)
+}
+
+public final class DefaultAPIClient: APIClient {
+    public static let shared = DefaultAPIClient()
+
+    private init() {}
+
+    public func request(_ request: Request, completion: @escaping (Result<Data, APIError>) -> Void) {
+        AF.request(request.makeRequest()).responseData { response in
+            switch response.result {
+            case .success(let data):
+                completion(.success(data))
+            case .failure:
+                completion(.failure(response.response?.statusCode == nil ? .network : .server))
+            }
+        }
+    }
+}

--- a/rakuten_ranking_app/Models/API/APIClient.swift
+++ b/rakuten_ranking_app/Models/API/APIClient.swift
@@ -8,7 +8,8 @@
 import Foundation
 import Alamofire
 
-public enum APIError: Error {
+
+enum APIError: Error {
     case network
     case server
     case invalidJSON
@@ -32,8 +33,8 @@ public enum HTTPMethod: String {
     case get
 }
 
+//ここで直接getなどを指定するのは良くない→別の場所で持たせる/APIClientクラスかDefaultAPIClientクラスでapplicationId入れられると良い
 public protocol Request {
-    var baseURL: URL { get }
     var method: HTTPMethod { get }
     var path: String { get }
     var headerFields: [String: String] { get }
@@ -63,6 +64,11 @@ public extension Request {
     }
 
     func makeRequest() -> URLRequest {
+        let baseURL = const.baseURL
+        // URL型に変換
+        guard let baseURL = URL(string: baseURL) else {
+            fatalError("無効なbaseURL")
+        }
         let url = path.isEmpty ? baseURL : baseURL.appendingPathComponent(path)
         var urlRequest = URLRequest(url: url, timeoutInterval: timeout)
         urlRequest.httpMethod = method.rawValue
@@ -82,11 +88,11 @@ public extension Request {
     }
 }
 
-public protocol APIClient {
+protocol APIClient {
     func request(_ request: Request, completion: @escaping (Result<Data, APIError>) -> Void)
 }
 
-public final class DefaultAPIClient: APIClient {
+final class DefaultAPIClient: APIClient {
     public static let shared = DefaultAPIClient()
 
     private init() {}

--- a/rakuten_ranking_app/Models/API/APIClient.swift
+++ b/rakuten_ranking_app/Models/API/APIClient.swift
@@ -33,12 +33,10 @@ public enum HTTPMethod: String {
     case get
 }
 
-//ここで直接getなどを指定するのは良くない→別の場所で持たせる/APIClientクラスかDefaultAPIClientクラスでapplicationId入れられると良い
 public protocol Request {
     var method: HTTPMethod { get }
     var path: String { get }
     var headerFields: [String: String] { get }
-    var parameter: [String: Any] { get }
     var timeout: TimeInterval { get }
     var contentType: String { get }
     var accept: String { get }
@@ -65,18 +63,20 @@ public extension Request {
 
     func makeRequest() -> URLRequest {
         let baseURL = const.baseURL
-        // URL型に変換
         guard let baseURL = URL(string: baseURL) else {
             fatalError("無効なbaseURL")
         }
         let url = path.isEmpty ? baseURL : baseURL.appendingPathComponent(path)
         var urlRequest = URLRequest(url: url, timeoutInterval: timeout)
         urlRequest.httpMethod = method.rawValue
-        if !parameter.isEmpty {
-            if let request = try? URLEncoding.default.encode(urlRequest, with: parameter) {
-                urlRequest = request
+        
+        let parameter: Parameters? = ["applicationId": const.applicationId]
+            if let parameter = parameter, !parameter.isEmpty {
+                if let request = try? URLEncoding.default.encode(urlRequest, with: parameter) {
+                     urlRequest = request
             }
         }
+        
         headerFields.forEach { key, value in
             urlRequest.setValue(value, forHTTPHeaderField: key)
         }

--- a/rakuten_ranking_app/Models/API/APIClient.swift
+++ b/rakuten_ranking_app/Models/API/APIClient.swift
@@ -28,25 +28,24 @@ extension APIError: LocalizedError {
     }
 }
 
-public enum HTTPMethod: String {
+enum HTTPMethod: String {
     case post
     case get
 }
 
-public protocol Request {
+protocol Request {
     var method: HTTPMethod { get }
     var path: String { get }
     var headerFields: [String: String] { get }
     var timeout: TimeInterval { get }
     var contentType: String { get }
     var accept: String { get }
-    //parameters プロパティを Request プロトコルに戻す
     var parameters: [String: Any] { get }
     
     func makeRequest() -> URLRequest
 }
 
-public extension Request {
+extension Request {
     var headerFields: [String: String] {
         return [:]
     }
@@ -64,7 +63,7 @@ public extension Request {
     }
 
     func makeRequest() -> URLRequest {
-        let baseURL = const.baseURL
+        let baseURL = Const.baseURL
         guard let baseURL = URL(string: baseURL) else {
             fatalError("無効なbaseURL")
         }
@@ -72,14 +71,10 @@ public extension Request {
         var urlRequest = URLRequest(url: url, timeoutInterval: timeout)
         urlRequest.httpMethod = method.rawValue
         
-        //protocolのparameterを取得し、一旦ローカル変数に代入してあげる
         var parameters = self.parameters
-        //parameterにupdateValueでapplicationIdの情報を追加する
-        parameters.updateValue(const.applicationId, forKey: "applicationId")
-        //URLパラメータを構築する
+        parameters.updateValue(Const.applicationId, forKey: "applicationId")
         var urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false)!
         var queryItems = [URLQueryItem]()
-        //パラメータをURLクエリ項目に変換する
         for (key, value) in parameters {
             queryItems.append(URLQueryItem(name: key, value: "\(value)"))
         }

--- a/rakuten_ranking_app/Models/API/APIClient.swift
+++ b/rakuten_ranking_app/Models/API/APIClient.swift
@@ -40,6 +40,8 @@ public protocol Request {
     var timeout: TimeInterval { get }
     var contentType: String { get }
     var accept: String { get }
+    //parameters プロパティを Request プロトコルに戻
+    var parameters: [String: Any] { get }
     
     func makeRequest() -> URLRequest
 }
@@ -70,12 +72,17 @@ public extension Request {
         var urlRequest = URLRequest(url: url, timeoutInterval: timeout)
         urlRequest.httpMethod = method.rawValue
         
-        let parameter: Parameters? = ["applicationId": const.applicationId]
-            if let parameter = parameter, !parameter.isEmpty {
-                if let request = try? URLEncoding.default.encode(urlRequest, with: parameter) {
-                     urlRequest = request
+        //protocolのparameterを取得し、一旦ローカル変数に代入してあげる
+        var parameters = self.parameters
+        //parameterにupdateValueでapplicationIdの情報を追加する
+        parameters.updateValue(const.applicationId, forKey: "applicationId")
+        
+        if !parameters.isEmpty {
+            if let request = try? URLEncoding.default.encode(urlRequest, with: parameters) {
+                urlRequest = request
             }
         }
+
         
         headerFields.forEach { key, value in
             urlRequest.setValue(value, forHTTPHeaderField: key)

--- a/rakuten_ranking_app/Models/API/APIClient.swift
+++ b/rakuten_ranking_app/Models/API/APIClient.swift
@@ -98,7 +98,7 @@ protocol APIClient {
     func request(_ request: Request, completion: @escaping (Result<Data, APIError>) -> Void)
 }
 
-final class DefaultAPIClient: APIClient {
+class DefaultAPIClient: APIClient {
     public static let shared = DefaultAPIClient()
 
     private init() {}

--- a/rakuten_ranking_app/Models/API/RankingAPI.swift
+++ b/rakuten_ranking_app/Models/API/RankingAPI.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 
-public class RankingAPI{
+class RankingAPI{
     private let apiClient: APIClient
 
     init(apiClient: APIClient) {
@@ -32,19 +32,19 @@ public class RankingAPI{
     }
 }
 
-public protocol RankingRequest: Request {}
+protocol RankingRequest: Request {}
 
-public extension RankingRequest {
+extension RankingRequest {
     var method: HTTPMethod {
         return .get
     }
     
     var path: String {
-        return const.urlPath
+        return Const.rankingAPIUrlPath
     }
 }
 
-public enum RankingAPIRequest: RankingRequest {
+enum RankingAPIRequest: RankingRequest {
     case getRanking(sex: String)
 
     public var parameters: [String: Any] {

--- a/rakuten_ranking_app/Models/API/RankingAPI.swift
+++ b/rakuten_ranking_app/Models/API/RankingAPI.swift
@@ -16,8 +16,8 @@ public class RankingAPI{
     }
     
     
-    func requestRanking(itemCode: String, completion: @escaping (Result<Ranking, APIError>) -> Void){
-        apiClient.request(RankingAPIRequest.getRanking(itemCode: itemCode)) { result in
+    func requestRanking(sex: String, completion: @escaping (Result<Ranking, APIError>) -> Void){
+        apiClient.request(RankingAPIRequest.getRanking(sex: sex)) { result in
             switch result {
             case .success(let data):
                 if let result = try? JSONDecoder().decode(Ranking.self, from: data) {
@@ -56,11 +56,15 @@ public extension RankingRequest {
 }
 
 public enum RankingAPIRequest: RankingRequest {
-    case getRanking(itemCode: String)
+    case getRanking(sex: String)
     public var parameter: [String: Any] {
         switch self {
-        case .getRanking(let itemCode):
-            return ["itemCode": itemCode]
+        case .getRanking(let sex):
+            if sex.isEmpty {
+                return [:]
+            } else {
+                return ["sex": sex]
+            }
         }
     }
 }

--- a/rakuten_ranking_app/Models/API/RankingAPI.swift
+++ b/rakuten_ranking_app/Models/API/RankingAPI.swift
@@ -36,12 +36,6 @@ public class RankingAPI{
 public protocol RankingRequest: Request {}
 
 public extension RankingRequest {
-    /*
-      APIのURLを作成するときにbaseURLをAPICommonURLから引っ張ってくる
-      それ以降のURLを let　xxx = "IchibaItem/Ranking/20220601?applicationId=1054850339030324271"として定義し、使う時に
-      fetchUrl = baseURL + xxxの様にして作成したい
-      URL()の括弧内に上記のurlを代入？
-    */
     var method: HTTPMethod {
         return .get
     }

--- a/rakuten_ranking_app/Models/API/RankingAPI.swift
+++ b/rakuten_ranking_app/Models/API/RankingAPI.swift
@@ -17,7 +17,7 @@ class RankingAPI{
     }
    
     //性別フィルター（sex）を使用してランキングデータを取得
-    func requestRanking(sex: String, completion: @escaping (Result<Ranking, APIError>) -> Void) {
+    func requestRanking(sex: RankingModel.SexType, completion: @escaping (Result<Ranking, APIError>) -> Void) {
         apiClient.request(RankingAPIRequest.getRanking(sex: sex)) { result in
             switch result {
             case .success(let data):
@@ -48,20 +48,18 @@ extension RankingRequest {
 
 enum RankingAPIRequest: RankingRequest {
     //性別フィルターを受け取り、それに応じたリクエストを作成
-    case getRanking(sex: String)
+    case getRanking(sex: RankingModel.SexType)
     //性別フィルターに基づいてリクエストのパラメータを設定
     public var parameters: [String: Any] {
         switch self {
         case .getRanking(let sex):
           switch sex {
-              case "all":
+          case .all:
                return [:]
-              case "male":
-                return ["sex": 1]
-              case "female":
-                return ["sex": 2]
-              default:
-                return [:]
+          case .male:
+               return ["sex": 1]
+          case .female:
+               return ["sex": 2]
           }
         }
     }

--- a/rakuten_ranking_app/Models/API/RankingAPI.swift
+++ b/rakuten_ranking_app/Models/API/RankingAPI.swift
@@ -7,11 +7,12 @@
 
 import Foundation
 
+
 public class RankingAPI{
     private let apiClient: APIClient
 
     
-    public init(apiClient: APIClient) {
+    init(apiClient: APIClient) {
       self.apiClient = apiClient
     }
     
@@ -32,26 +33,21 @@ public class RankingAPI{
     }
 }
 
-public protocol RankingRequest: Request {
-}
+public protocol RankingRequest: Request {}
 
 public extension RankingRequest {
-    var baseURL: URL {
-        #if DEBUG
-          // デバッグ（必要であればここでURLを開発用途化に変える）*別モジュールなのでDUMMYは使えない
-          return URL(string: "https://app.rakuten.co.jp/services/api/IchibaItem/Ranking/20220601?applicationId=1054850339030324271")!
-        #else
-          // 本番
-          return URL(string: "https://app.rakuten.co.jp/services/api/IchibaItem/Ranking/20220601?applicationId=1054850339030324271")!
-        #endif
-    }
-
+    /*
+      APIのURLを作成するときにbaseURLをAPICommonURLから引っ張ってくる
+      それ以降のURLを let　xxx = "IchibaItem/Ranking/20220601?applicationId=1054850339030324271"として定義し、使う時に
+      fetchUrl = baseURL + xxxの様にして作成したい
+      URL()の括弧内に上記のurlを代入？
+    */
     var method: HTTPMethod {
         return .get
     }
-
+    
     var path: String {
-        return ""
+        return const.urlPath
     }
 }
 

--- a/rakuten_ranking_app/Models/API/RankingAPI.swift
+++ b/rakuten_ranking_app/Models/API/RankingAPI.swift
@@ -11,19 +11,18 @@ import Foundation
 public class RankingAPI{
     private let apiClient: APIClient
 
-    
     init(apiClient: APIClient) {
       self.apiClient = apiClient
     }
-    
-    
-    func requestRanking(sex: String, completion: @escaping (Result<Ranking, APIError>) -> Void){
+   
+    func requestRanking(sex: String, completion: @escaping (Result<Ranking, APIError>) -> Void) {
         apiClient.request(RankingAPIRequest.getRanking(sex: sex)) { result in
             switch result {
             case .success(let data):
-                if let result = try? JSONDecoder().decode(Ranking.self, from: data) {
+                do {
+                    let result = try JSONDecoder().decode(Ranking.self, from: data)
                     completion(.success(result))
-                } else {
+                } catch {
                     completion(.failure(.invalidJSON))
                 }
             case .failure(let error):
@@ -47,14 +46,15 @@ public extension RankingRequest {
 
 public enum RankingAPIRequest: RankingRequest {
     case getRanking(sex: String)
-    public var parameter: [String: Any] {
+
+    public var parameters: [String: Any] {
         switch self {
         case .getRanking(let sex):
-            if sex.isEmpty {
-                return [:]
-            } else {
-                return ["sex": sex]
-            }
+          if sex.isEmpty {
+            return [:]
+          } else {
+            return ["sex": sex]
+          }
         }
     }
 }

--- a/rakuten_ranking_app/Models/API/RankingAPI.swift
+++ b/rakuten_ranking_app/Models/API/RankingAPI.swift
@@ -40,7 +40,7 @@ extension RankingRequest {
     }
     
     var path: String {
-        return Const.rankingAPIUrlPath
+        return APIPathConst.rankingAPIUrlPath
     }
 }
 

--- a/rakuten_ranking_app/Models/API/RankingAPI.swift
+++ b/rakuten_ranking_app/Models/API/RankingAPI.swift
@@ -7,14 +7,16 @@
 
 import Foundation
 
-
+//APIクライアントを通じてランキングデータを取得す
 class RankingAPI{
     private let apiClient: APIClient
 
+    //apiClientを初期化
     init(apiClient: APIClient) {
       self.apiClient = apiClient
     }
    
+    //性別フィルター（sex）を使用してランキングデータを取得
     func requestRanking(sex: String, completion: @escaping (Result<Ranking, APIError>) -> Void) {
         apiClient.request(RankingAPIRequest.getRanking(sex: sex)) { result in
             switch result {
@@ -45,15 +47,21 @@ extension RankingRequest {
 }
 
 enum RankingAPIRequest: RankingRequest {
+    //性別フィルターを受け取り、それに応じたリクエストを作成
     case getRanking(sex: String)
-
+    //性別フィルターに基づいてリクエストのパラメータを設定
     public var parameters: [String: Any] {
         switch self {
         case .getRanking(let sex):
-          if sex.isEmpty {
-            return [:]
-          } else {
-            return ["sex": sex]
+          switch sex {
+              case "all":
+               return [:]
+              case "male":
+                return ["sex": 1]
+              case "female":
+                return ["sex": 2]
+              default:
+                return [:]
           }
         }
     }

--- a/rakuten_ranking_app/Models/API/RankingAPI.swift
+++ b/rakuten_ranking_app/Models/API/RankingAPI.swift
@@ -1,0 +1,69 @@
+//
+//  RankingAPI.swift
+//  rakuten_ranking_app
+//
+//  Created by 櫻田龍之助 on 2024/05/13.
+//
+
+import Foundation
+
+public class RankingAPI{
+    private let apiClient: APIClient
+
+    
+    public init(apiClient: APIClient) {
+      self.apiClient = apiClient
+    }
+    
+    
+    func requestRanking(itemCode: String, completion: @escaping (Result<Ranking, APIError>) -> Void){
+        apiClient.request(RankingAPIRequest.getRanking(itemCode: itemCode)) { result in
+            switch result {
+            case .success(let data):
+                if let result = try? JSONDecoder().decode(Ranking.self, from: data) {
+                    completion(.success(result))
+                } else {
+                    completion(.failure(.invalidJSON))
+                }
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        }
+    }
+}
+
+public protocol RankingRequest: Request {
+}
+
+public extension RankingRequest {
+    var baseURL: URL {
+        #if DEBUG
+          // デバッグ（必要であればここでURLを開発用途化に変える）*別モジュールなのでDUMMYは使えない
+          return URL(string: "https://app.rakuten.co.jp/services/api/IchibaItem/Ranking/20220601?applicationId=1054850339030324271")!
+        #else
+          // 本番
+          return URL(string: "https://app.rakuten.co.jp/services/api/IchibaItem/Ranking/20220601?applicationId=1054850339030324271")!
+        #endif
+    }
+
+    var method: HTTPMethod {
+        return .get
+    }
+
+    var path: String {
+        return ""
+    }
+}
+
+public enum RankingAPIRequest: RankingRequest {
+    case getRanking(itemCode: String)
+    public var parameter: [String: Any] {
+        switch self {
+        case .getRanking(let itemCode):
+            return ["itemCode": itemCode]
+        }
+    }
+}
+
+                          
+

--- a/rakuten_ranking_app/Models/JSONExport/Ranking.swift
+++ b/rakuten_ranking_app/Models/JSONExport/Ranking.swift
@@ -1,0 +1,75 @@
+//
+//  Ranking.swift
+//  rakuten_ranking_app
+//
+//  Created by 櫻田龍之助 on 2024/05/13.
+//
+
+///データクラスの作成
+import Foundation
+
+struct Ranking: Codable {
+    let items: [ItemElement]
+
+    enum CodingKeys: String, CodingKey {
+        case items = "Items"
+    }
+}
+
+struct ItemElement: Codable {
+    let item: Item
+
+    enum CodingKeys: String, CodingKey {
+        case item = "Item"
+    }
+}
+
+struct Item: Codable {
+    let affiliateRate, affiliateURL, asurakuArea, asurakuClosingTime: String
+    let asurakuFlag, availability, carrier: Int
+    let catchcopy: String
+    let creditCardFlag: Int
+    let endTime, genreID: String
+    let hasPriceRange, imageFlag: Int
+    let itemCaption, itemCode, itemName, itemPrice: String
+    let itemPriceBaseField, itemPriceMax1, itemPriceMax2, itemPriceMax3: String
+    let itemPriceMin1, itemPriceMin2, itemPriceMin3: String
+    let itemURL: String
+    let mediumImageUrls: [ImageURL]
+    let pointRate: Int
+    let pointRateEndTime, pointRateStartTime: String
+    let postageFlag, rank: Int
+    let reviewAverage: String
+    let reviewCount: Int
+    let shipOverseasArea: String
+    let shipOverseasFlag: Int
+    let shopAffiliateURL, shopCode, shopName: String
+    let shopOfTheYearFlag: Int
+    let shopURL: String
+    let smallImageUrls: [ImageURL]
+    let startTime: String
+    let taxFlag: Int
+
+    enum CodingKeys: String, CodingKey {
+        case affiliateRate
+        case affiliateURL = "affiliateUrl"
+        case asurakuArea, asurakuClosingTime, asurakuFlag, availability, carrier, catchcopy, creditCardFlag, endTime
+        case genreID = "genreId"
+        case hasPriceRange, imageFlag, itemCaption, itemCode, itemName, itemPrice, itemPriceBaseField, itemPriceMax1, itemPriceMax2, itemPriceMax3, itemPriceMin1, itemPriceMin2, itemPriceMin3
+        case itemURL = "itemUrl"
+        case mediumImageUrls, pointRate, pointRateEndTime, pointRateStartTime, postageFlag, rank, reviewAverage, reviewCount, shipOverseasArea, shipOverseasFlag
+        case shopAffiliateURL = "shopAffiliateUrl"
+        case shopCode, shopName, shopOfTheYearFlag
+        case shopURL = "shopUrl"
+        case smallImageUrls, startTime, taxFlag
+    }
+}
+
+struct ImageURL: Codable {
+    let imageURL: String
+
+    enum CodingKeys: String, CodingKey {
+        case imageURL = "imageUrl"
+    }
+}
+

--- a/rakuten_ranking_app/Models/JSONExport/Ranking.swift
+++ b/rakuten_ranking_app/Models/JSONExport/Ranking.swift
@@ -8,47 +8,52 @@
 ///データクラスの作成
 import Foundation
 
-struct Ranking: Codable {
-    let items: [ItemElement]
+public struct Ranking: Codable {
+    public var items: [ItemElement]
 
     enum CodingKeys: String, CodingKey {
         case items = "Items"
     }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        items = try container.decodeIfPresent([ItemElement].self, forKey: .items) ?? []
+    }
 }
 
-struct ItemElement: Codable {
-    let item: Item
+public struct ItemElement: Codable {
+    public let item: Item
 
     enum CodingKeys: String, CodingKey {
         case item = "Item"
     }
 }
 
-struct Item: Codable {
-    let affiliateRate, affiliateURL, asurakuArea, asurakuClosingTime: String
-    let asurakuFlag, availability, carrier: Int
-    let catchcopy: String
-    let creditCardFlag: Int
-    let endTime, genreID: String
-    let hasPriceRange, imageFlag: Int
-    let itemCaption, itemCode, itemName, itemPrice: String
-    let itemPriceBaseField, itemPriceMax1, itemPriceMax2, itemPriceMax3: String
-    let itemPriceMin1, itemPriceMin2, itemPriceMin3: String
-    let itemURL: String
-    let mediumImageUrls: [ImageURL]
-    let pointRate: Int
-    let pointRateEndTime, pointRateStartTime: String
-    let postageFlag, rank: Int
-    let reviewAverage: String
-    let reviewCount: Int
-    let shipOverseasArea: String
-    let shipOverseasFlag: Int
-    let shopAffiliateURL, shopCode, shopName: String
-    let shopOfTheYearFlag: Int
-    let shopURL: String
-    let smallImageUrls: [ImageURL]
-    let startTime: String
-    let taxFlag: Int
+public struct Item: Codable {
+    public let affiliateRate, affiliateURL, asurakuArea, asurakuClosingTime: String
+    public let asurakuFlag, availability, carrier: Int
+    public let catchcopy: String
+    public let creditCardFlag: Int
+    public let endTime, genreID: String
+    public let hasPriceRange, imageFlag: Int
+    public let itemCaption, itemCode, itemName, itemPrice: String
+    public let itemPriceBaseField, itemPriceMax1, itemPriceMax2, itemPriceMax3: String
+    public let itemPriceMin1, itemPriceMin2, itemPriceMin3: String
+    public let itemURL: String
+    public let mediumImageUrls: [ImageURL]
+    public let pointRate: Int
+    public let pointRateEndTime, pointRateStartTime: String
+    public let postageFlag, rank: Int
+    public let reviewAverage: String
+    public let reviewCount: Int
+    public let shipOverseasArea: String
+    public let shipOverseasFlag: Int
+    public let shopAffiliateURL, shopCode, shopName: String
+    public let shopOfTheYearFlag: Int
+    public let shopURL: String
+    public let smallImageUrls: [ImageURL]
+    public let startTime: String
+    public let taxFlag: Int
 
     enum CodingKeys: String, CodingKey {
         case affiliateRate
@@ -63,13 +68,64 @@ struct Item: Codable {
         case shopURL = "shopUrl"
         case smallImageUrls, startTime, taxFlag
     }
+    
+    public init(from decoder: Decoder) throws {
+      let container = try decoder.container(keyedBy: CodingKeys.self)
+           affiliateRate = try container.decodeIfPresent(String.self, forKey: .affiliateRate) ?? ""
+           affiliateURL = try container.decodeIfPresent(String.self, forKey: .affiliateURL) ?? ""
+           asurakuArea = try container.decodeIfPresent(String.self, forKey: .asurakuArea) ?? ""
+           asurakuClosingTime = try container.decodeIfPresent(String.self, forKey: .asurakuClosingTime) ?? ""
+           asurakuFlag = try container.decodeIfPresent(Int.self, forKey: .asurakuFlag) ?? 0
+           availability = try container.decodeIfPresent(Int.self, forKey: .availability) ?? 0
+           carrier = try container.decodeIfPresent(Int.self, forKey: .carrier) ?? 0
+           catchcopy = try container.decodeIfPresent(String.self, forKey: .catchcopy) ?? ""
+           creditCardFlag = try container.decodeIfPresent(Int.self, forKey: .creditCardFlag) ?? 0
+           endTime = try container.decodeIfPresent(String.self, forKey: .endTime) ?? ""
+           genreID = try container.decodeIfPresent(String.self, forKey: .genreID) ?? ""
+           hasPriceRange = try container.decodeIfPresent(Int.self, forKey: .hasPriceRange) ?? 0
+           imageFlag = try container.decodeIfPresent(Int.self, forKey: .imageFlag) ?? 0
+           itemCaption = try container.decodeIfPresent(String.self, forKey: .itemCaption) ?? ""
+           itemCode = try container.decodeIfPresent(String.self, forKey: .itemCode) ?? ""
+           itemName = try container.decodeIfPresent(String.self, forKey: .itemName) ?? ""
+           itemPrice = try container.decodeIfPresent(String.self, forKey: .itemPrice) ?? ""
+           itemPriceBaseField = try container.decodeIfPresent(String.self, forKey: .itemPriceBaseField) ?? ""
+           itemPriceMax1 = try container.decodeIfPresent(String.self, forKey: .itemPriceMax1) ?? ""
+           itemPriceMax2 = try container.decodeIfPresent(String.self, forKey: .itemPriceMax2) ?? ""
+           itemPriceMax3 = try container.decodeIfPresent(String.self, forKey: .itemPriceMax3) ?? ""
+           itemPriceMin1 = try container.decodeIfPresent(String.self, forKey: .itemPriceMin1) ?? ""
+           itemPriceMin2 = try container.decodeIfPresent(String.self, forKey: .itemPriceMin2) ?? ""
+           itemPriceMin3 = try container.decodeIfPresent(String.self, forKey: .itemPriceMin3) ?? ""
+           itemURL = try container.decodeIfPresent(String.self, forKey: .itemURL) ?? ""
+           mediumImageUrls = try container.decodeIfPresent([ImageURL].self, forKey: .mediumImageUrls) ?? []
+           pointRate = try container.decodeIfPresent(Int.self, forKey: .pointRate) ?? 0
+           pointRateEndTime = try container.decodeIfPresent(String.self, forKey: .pointRateEndTime) ?? ""
+           pointRateStartTime = try container.decodeIfPresent(String.self, forKey: .pointRateStartTime) ?? ""
+           postageFlag = try container.decodeIfPresent(Int.self, forKey: .postageFlag) ?? 0
+           rank = try container.decodeIfPresent(Int.self, forKey: .rank) ?? 0
+           reviewAverage = try container.decodeIfPresent(String.self, forKey: .reviewAverage) ?? ""
+           reviewCount = try container.decodeIfPresent(Int.self, forKey: .reviewCount) ?? 0
+           shipOverseasArea = try container.decodeIfPresent(String.self, forKey: .shipOverseasArea) ?? ""
+           shipOverseasFlag = try container.decodeIfPresent(Int.self, forKey: .shipOverseasFlag) ?? 0
+           shopAffiliateURL = try container.decodeIfPresent(String.self, forKey: .shopAffiliateURL) ?? ""
+           shopCode = try container.decodeIfPresent(String.self, forKey: .shopCode) ?? ""
+           shopName = try container.decodeIfPresent(String.self, forKey: .shopName) ?? ""
+           shopOfTheYearFlag = try container.decodeIfPresent(Int.self, forKey: .shopOfTheYearFlag) ?? 0
+           shopURL = try container.decodeIfPresent(String.self, forKey: .shopURL) ?? ""
+           smallImageUrls = try container.decodeIfPresent([ImageURL].self, forKey: .smallImageUrls) ?? []
+           startTime = try container.decodeIfPresent(String.self, forKey: .startTime) ?? ""
+           taxFlag = try container.decodeIfPresent(Int.self, forKey: .taxFlag) ?? 0
+    }
 }
 
-struct ImageURL: Codable {
-    let imageURL: String
+public struct ImageURL: Codable {
+    public let imageURL: String
 
     enum CodingKeys: String, CodingKey {
         case imageURL = "imageUrl"
     }
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        imageURL = try container.decodeIfPresent(String.self, forKey: .imageURL) ?? ""
+    }
 }
-

--- a/rakuten_ranking_app/Models/JSONExport/Ranking.swift
+++ b/rakuten_ranking_app/Models/JSONExport/Ranking.swift
@@ -5,55 +5,62 @@
 //  Created by 櫻田龍之助 on 2024/05/13.
 //
 
-///データクラスの作成
+
 import Foundation
 
-public struct Ranking: Codable {
-    public var items: [ItemElement]
+struct Ranking: Codable {
+    var items: [ItemElement]
 
     enum CodingKeys: String, CodingKey {
         case items = "Items"
     }
 
-    public init(from decoder: Decoder) throws {
+    init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         items = try container.decodeIfPresent([ItemElement].self, forKey: .items) ?? []
     }
+    
+    func printData() {
+        for itemElement in items {
+            let item = itemElement.item
+            print("商品名: \(item.itemName)")
+        }
+    }
 }
 
-public struct ItemElement: Codable {
-    public let item: Item
+struct ItemElement: Codable {
+    let item: Item
 
     enum CodingKeys: String, CodingKey {
         case item = "Item"
     }
 }
 
-public struct Item: Codable {
-    public let affiliateRate, affiliateURL, asurakuArea, asurakuClosingTime: String
-    public let asurakuFlag, availability, carrier: Int
-    public let catchcopy: String
-    public let creditCardFlag: Int
-    public let endTime, genreID: String
-    public let hasPriceRange, imageFlag: Int
-    public let itemCaption, itemCode, itemName, itemPrice: String
-    public let itemPriceBaseField, itemPriceMax1, itemPriceMax2, itemPriceMax3: String
-    public let itemPriceMin1, itemPriceMin2, itemPriceMin3: String
-    public let itemURL: String
-    public let mediumImageUrls: [ImageURL]
-    public let pointRate: Int
-    public let pointRateEndTime, pointRateStartTime: String
-    public let postageFlag, rank: Int
-    public let reviewAverage: String
-    public let reviewCount: Int
-    public let shipOverseasArea: String
-    public let shipOverseasFlag: Int
-    public let shopAffiliateURL, shopCode, shopName: String
-    public let shopOfTheYearFlag: Int
-    public let shopURL: String
-    public let smallImageUrls: [ImageURL]
-    public let startTime: String
-    public let taxFlag: Int
+struct Item: Codable {
+    let affiliateRate, affiliateURL, asurakuArea, asurakuClosingTime: String
+    let asurakuFlag, availability, carrier: Int
+    let catchcopy: String
+    let creditCardFlag: Int
+    let endTime, genreID: String
+    let hasPriceRange, imageFlag: Int
+    let itemCaption, itemCode, itemName, itemPrice: String
+    let itemPriceBaseField, itemPriceMax1, itemPriceMax2, itemPriceMax3: String
+    let itemPriceMin1, itemPriceMin2, itemPriceMin3: String
+    let itemURL: String
+    let mediumImageUrls: [ImageURL]
+    let pointRate: Int
+    let pointRateEndTime, pointRateStartTime: String
+    let postageFlag, rank: Int
+    let reviewAverage: String
+    let reviewCount: Int
+    let shipOverseasArea: String
+    let shipOverseasFlag: Int
+    let shopAffiliateURL, shopCode, shopName: String
+    let shopOfTheYearFlag: Int
+    let shopURL: String
+    let smallImageUrls: [ImageURL]
+    let startTime: String
+    let taxFlag: Int
 
     enum CodingKeys: String, CodingKey {
         case affiliateRate
@@ -69,7 +76,7 @@ public struct Item: Codable {
         case smallImageUrls, startTime, taxFlag
     }
     
-    public init(from decoder: Decoder) throws {
+   init(from decoder: Decoder) throws {
       let container = try decoder.container(keyedBy: CodingKeys.self)
            affiliateRate = try container.decodeIfPresent(String.self, forKey: .affiliateRate) ?? ""
            affiliateURL = try container.decodeIfPresent(String.self, forKey: .affiliateURL) ?? ""
@@ -117,14 +124,14 @@ public struct Item: Codable {
     }
 }
 
-public struct ImageURL: Codable {
-    public let imageURL: String
+struct ImageURL: Codable {
+    let imageURL: String
 
     enum CodingKeys: String, CodingKey {
         case imageURL = "imageUrl"
     }
     
-    public init(from decoder: Decoder) throws {
+    init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         imageURL = try container.decodeIfPresent(String.self, forKey: .imageURL) ?? ""
     }

--- a/rakuten_ranking_app/Models/Ranking/RankingModel.swift
+++ b/rakuten_ranking_app/Models/Ranking/RankingModel.swift
@@ -11,9 +11,9 @@ final class RankingModel {
     let notificationCenter = NotificationCenter.default
     private(set) var ranking: Ranking! {
         didSet {
-            notificationCenter.post(name: .init(rawValue: Const.notificationName),
+            notificationCenter.post(name: .init(rawValue: NotificationConst.rankingNotificationName),
                                     object: nil,
-                                    userInfo: [Const.notificationName: ranking!])
+                                    userInfo: [NotificationConst.rankingNotificationName: ranking!])
         }
     }
     private let rankingAPI: RankingAPI

--- a/rakuten_ranking_app/Models/Ranking/RankingModel.swift
+++ b/rakuten_ranking_app/Models/Ranking/RankingModel.swift
@@ -17,21 +17,52 @@ final class RankingModel {
         }
     }
     private let rankingAPI: RankingAPI
-    private let itemCode: String
-
-    public init(itemCode: String, apiClient: APIClient) {
-        self.itemCode = itemCode
-        self.rankingAPI = .init(apiClient: apiClient)
-    }
-
-    public func requestRanking(_ completion: @escaping (Result<Ranking, APIError>) -> Void) {
-        rankingAPI.requestRanking(itemCode: itemCode) { [weak self] result in
-            DispatchQueue.main.async {
-                if case .success(let ranking) = result {
-                    self?.ranking = ranking
+    
+    enum SexType: Int {
+            case all = 0
+            case male = 1
+            case female = 2
+            
+            init(value: Int?) {
+                switch value {
+                case 1:
+                    self = .male
+                case 2:
+                    self = .female
+                default:
+                    self = .all
                 }
-                completion(result)
+            }
+            
+            var description: String {
+                switch self {
+                case .all:
+                    return "総合ランキング"
+                case .male:
+                    return "男性ランキング"
+                case .female:
+                    return "女性ランキング"
+                }
             }
         }
-    }
+
+    let sex: SexType
+    
+    public init(sex: Int? = nil, apiClient: APIClient) {
+           self.rankingAPI = .init(apiClient: apiClient)
+           self.sex = SexType(value: sex)
+           print("現在取得しているランキング: \(self.sex.description)")
+       }
+
+    
+       public func requestRanking() {
+           let sexValue = sex.rawValue == 0 ? "" : "\(sex.rawValue)"
+           rankingAPI.requestRanking(sex:sexValue) { [weak self] result in
+               DispatchQueue.main.async {
+                   if case .success(let ranking) = result {
+                       self?.ranking = ranking
+                   }
+               }
+           }
+       }
 }

--- a/rakuten_ranking_app/Models/Ranking/RankingModel.swift
+++ b/rakuten_ranking_app/Models/Ranking/RankingModel.swift
@@ -8,12 +8,12 @@
 import Foundation
 
 final class RankingModel {
-    public let notificationCenter = NotificationCenter.default
-    public private(set) var ranking: Ranking! {
+    let notificationCenter = NotificationCenter.default
+    private(set) var ranking: Ranking! {
         didSet {
-            notificationCenter.post(name: .init(rawValue: "ranking"),
+            notificationCenter.post(name: .init(rawValue: Const.notificationName),
                                     object: nil,
-                                    userInfo: ["ranking": ranking!])
+                                    userInfo: [Const.notificationName: ranking!])
         }
     }
     private let rankingAPI: RankingAPI
@@ -48,16 +48,16 @@ final class RankingModel {
 
     let sex: SexType
     
-    public init(sex: Int? = nil, apiClient: APIClient) {
+   init(sex: Int? = nil, apiClient: APIClient) {
            self.rankingAPI = .init(apiClient: apiClient)
            self.sex = SexType(value: sex)
            print("現在取得しているランキング: \(self.sex.description)")
     }
 
     
-    public func requestRanking() {
+    func requestRanking() {
         let sexValue = sex.rawValue == 0 ? "" : "\(sex.rawValue)"
-        rankingAPI.requestRanking(sex:sexValue) { [weak self] result in
+        rankingAPI.requestRanking(sex: sexValue) { [weak self] result in
             DispatchQueue.main.async {
                 if case .success(let ranking) = result {
                     self?.ranking = ranking

--- a/rakuten_ranking_app/Models/Ranking/RankingModel.swift
+++ b/rakuten_ranking_app/Models/Ranking/RankingModel.swift
@@ -53,7 +53,6 @@ final class RankingModel {
            self.sex = SexType(value: sex)
            print("現在取得しているランキング: \(self.sex.description)")
        }
-
     
        public func requestRanking() {
            let sexValue = sex.rawValue == 0 ? "" : "\(sex.rawValue)"

--- a/rakuten_ranking_app/Models/Ranking/RankingModel.swift
+++ b/rakuten_ranking_app/Models/Ranking/RankingModel.swift
@@ -52,16 +52,17 @@ final class RankingModel {
            self.rankingAPI = .init(apiClient: apiClient)
            self.sex = SexType(value: sex)
            print("現在取得しているランキング: \(self.sex.description)")
-       }
+    }
+
     
-       public func requestRanking() {
-           let sexValue = sex.rawValue == 0 ? "" : "\(sex.rawValue)"
-           rankingAPI.requestRanking(sex:sexValue) { [weak self] result in
-               DispatchQueue.main.async {
-                   if case .success(let ranking) = result {
-                       self?.ranking = ranking
-                   }
-               }
-           }
-       }
+    public func requestRanking() {
+        let sexValue = sex.rawValue == 0 ? "" : "\(sex.rawValue)"
+        rankingAPI.requestRanking(sex:sexValue) { [weak self] result in
+            DispatchQueue.main.async {
+                if case .success(let ranking) = result {
+                    self?.ranking = ranking
+                }
+            }
+        }
+    }
 }

--- a/rakuten_ranking_app/Models/Ranking/RankingModel.swift
+++ b/rakuten_ranking_app/Models/Ranking/RankingModel.swift
@@ -1,0 +1,37 @@
+//
+//  RankingModel.swift
+//  rakuten_ranking_app
+//
+//  Created by 櫻田龍之助 on 2024/05/13.
+//
+
+import Foundation
+
+final class RankingModel {
+    public let notificationCenter = NotificationCenter.default
+    public private(set) var ranking: Ranking! {
+        didSet {
+            notificationCenter.post(name: .init(rawValue: "ranking"),
+                                    object: nil,
+                                    userInfo: ["ranking": ranking!])
+        }
+    }
+    private let rankingAPI: RankingAPI
+    private let itemCode: String
+
+    public init(itemCode: String, apiClient: APIClient) {
+        self.itemCode = itemCode
+        self.rankingAPI = .init(apiClient: apiClient)
+    }
+
+    public func requestRanking(_ completion: @escaping (Result<Ranking, APIError>) -> Void) {
+        rankingAPI.requestRanking(itemCode: itemCode) { [weak self] result in
+            DispatchQueue.main.async {
+                if case .success(let ranking) = result {
+                    self?.ranking = ranking
+                }
+                completion(result)
+            }
+        }
+    }
+}

--- a/rakuten_ranking_app/Models/Ranking/RankingModel.swift
+++ b/rakuten_ranking_app/Models/Ranking/RankingModel.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-final class RankingModel {
+class RankingModel {
     let notificationCenter = NotificationCenter.default
     
     //取得したランキングデータを保持
@@ -29,18 +29,6 @@ final class RankingModel {
         case all
         case male
         case female
-        
-        //各ケースに対応する文字列値を取得
-        var sexValue: String {
-            switch self {
-              case .all:
-                return ""
-              case .male:
-                return "male"
-              case .female:
-                return "female"
-            }
-        }
    }
     
 
@@ -53,8 +41,7 @@ final class RankingModel {
 
    //指定された性別フィルターに基づいてランキングデータを取得
    func requestRanking() {
-       let sexValue = sex.sexValue
-       rankingAPI.requestRanking(sex: sexValue) { [weak self] result in
+       rankingAPI.requestRanking(sex: sex) { [weak self] result in
           DispatchQueue.main.async {
              if case .success(let ranking) = result {
                 self?.ranking = ranking

--- a/rakuten_ranking_app/Views/RankingForAllViewController.swift
+++ b/rakuten_ranking_app/Views/RankingForAllViewController.swift
@@ -6,7 +6,6 @@
 //
 
 import UIKit
-import Models
 
 final class RankingForAllViewController: UIViewController {
     
@@ -17,7 +16,7 @@ final class RankingForAllViewController: UIViewController {
     }
     
     deinit {
-           model.notificationCenter.removeObserver(self)
+      model.notificationCenter.removeObserver(self)
     }
 
     private func registerModel() {
@@ -32,11 +31,9 @@ final class RankingForAllViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        guard let ranking = model?.ranking else {
-              print("Error: model or model.ranking is nil")
-              return
-          }
-        printData(ranking: ranking)
+        
+        model = RankingModel(sex:1, apiClient: DefaultAPIClient.shared)
+        model.requestRanking()
     }
     
     private func printData(ranking: Ranking) {

--- a/rakuten_ranking_app/Views/RankingForAllViewController.swift
+++ b/rakuten_ranking_app/Views/RankingForAllViewController.swift
@@ -21,9 +21,9 @@ class RankingForAllViewController: UIViewController {
 
     private func registerModel() {
       _ = model.notificationCenter
-            .addObserver(forName: .init(rawValue: Const.notificationName),
+            .addObserver(forName: .init(rawValue: NotificationConst.rankingNotificationName),
                             object: nil, queue: nil) { notification in
-                               if let ranking = notification.userInfo?[Const.notificationName] as? Ranking {
+                               if let ranking = notification.userInfo?[NotificationConst.rankingNotificationName] as? Ranking {
                                    ranking.printData()
                                }
       }

--- a/rakuten_ranking_app/Views/RankingForAllViewController.swift
+++ b/rakuten_ranking_app/Views/RankingForAllViewController.swift
@@ -32,7 +32,7 @@ final class RankingForAllViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        model = RankingModel(sex:1, apiClient: DefaultAPIClient.shared)
+        model = RankingModel(apiClient: DefaultAPIClient.shared)
         model.requestRanking()
     }
     

--- a/rakuten_ranking_app/Views/RankingForAllViewController.swift
+++ b/rakuten_ranking_app/Views/RankingForAllViewController.swift
@@ -9,11 +9,36 @@ import UIKit
 
 
 class RankingForAllViewController: UIViewController {
+    
+    var model: RankingModel! {
+      didSet {
+        registerModel()
+      }
+    }
+    
+    deinit {
+           model.notificationCenter.removeObserver(self)
+    }
+
+    private func registerModel() {
+      _ = model.notificationCenter
+               .addObserver(forName: .init(rawValue: "ranking"),
+                            object: nil, queue: nil) { [weak self] notification in
+                               if let ranking = notification.userInfo?["ranking"] as? Ranking {
+                                   self?.printData(ranking: ranking)
+                               }
+      }
+    }
 
     override func viewDidLoad() {
         super.viewDidLoad()
-       
+        printData(ranking: model.ranking)
     }
     
-
+    private func printData(ranking: Ranking) {
+        for itemElement in ranking.items {
+              let item = itemElement.item
+              print("商品名: \(item.itemName)")
+          }
+    }
 }

--- a/rakuten_ranking_app/Views/RankingForAllViewController.swift
+++ b/rakuten_ranking_app/Views/RankingForAllViewController.swift
@@ -7,23 +7,31 @@
 
 import UIKit
 
+
 class RankingForAllViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        // Do any additional setup after loading the view.
+        fetchRankingData()
     }
     
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+    func fetchRankingData() {
+        let url: URL = URL(string: "https://app.rakuten.co.jp/services/api/IchibaItem/Ranking/20220601?applicationId=1054850339030324271")!
+        let task: URLSessionTask = URLSession.shared.dataTask(with: url, completionHandler: {(data, response, error) in
+          // コンソールに出力
+          print("data: \(String(describing: data))")
+          print("response: \(String(describing: response))")
+          print("error: \(String(describing: error))")
+          do{
+            //JSONに変換&バースする
+            let rankingData = try JSONSerialization.jsonObject(with: data!, options: JSONSerialization.ReadingOptions.allowFragments) as! [String: Any]
+              print(rankingData) // Jsonの中身を表示
+            }
+            catch {
+             print(error)
+            }
+          }
+        )
+        task.resume()
     }
-    */
-
 }

--- a/rakuten_ranking_app/Views/RankingForAllViewController.swift
+++ b/rakuten_ranking_app/Views/RankingForAllViewController.swift
@@ -38,8 +38,8 @@ final class RankingForAllViewController: UIViewController {
     
     private func printData(ranking: Ranking) {
         for itemElement in ranking.items {
-              let item = itemElement.item
-              print("商品名: \(item.itemName)")
-          }
+            let item = itemElement.item
+            print("商品名: \(item.itemName)")
+        }
     }
 }

--- a/rakuten_ranking_app/Views/RankingForAllViewController.swift
+++ b/rakuten_ranking_app/Views/RankingForAllViewController.swift
@@ -6,9 +6,9 @@
 //
 
 import UIKit
+import Models
 
-
-class RankingForAllViewController: UIViewController {
+final class RankingForAllViewController: UIViewController {
     
     var model: RankingModel! {
       didSet {
@@ -32,7 +32,11 @@ class RankingForAllViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        printData(ranking: model.ranking)
+        guard let ranking = model?.ranking else {
+              print("Error: model or model.ranking is nil")
+              return
+          }
+        printData(ranking: ranking)
     }
     
     private func printData(ranking: Ranking) {

--- a/rakuten_ranking_app/Views/RankingForAllViewController.swift
+++ b/rakuten_ranking_app/Views/RankingForAllViewController.swift
@@ -12,26 +12,8 @@ class RankingForAllViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        fetchRankingData()
+       
     }
     
-    func fetchRankingData() {
-        let url: URL = URL(string: "https://app.rakuten.co.jp/services/api/IchibaItem/Ranking/20220601?applicationId=1054850339030324271")!
-        let task: URLSessionTask = URLSession.shared.dataTask(with: url, completionHandler: {(data, response, error) in
-          // コンソールに出力
-          print("data: \(String(describing: data))")
-          print("response: \(String(describing: response))")
-          print("error: \(String(describing: error))")
-          do{
-            //JSONに変換&バースする
-            let rankingData = try JSONSerialization.jsonObject(with: data!, options: JSONSerialization.ReadingOptions.allowFragments) as! [String: Any]
-              print(rankingData) // Jsonの中身を表示
-            }
-            catch {
-             print(error)
-            }
-          }
-        )
-        task.resume()
-    }
+
 }

--- a/rakuten_ranking_app/Views/RankingForAllViewController.swift
+++ b/rakuten_ranking_app/Views/RankingForAllViewController.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-final class RankingForAllViewController: UIViewController {
+class RankingForAllViewController: UIViewController {
     
     var model: RankingModel! {
       didSet {
@@ -21,10 +21,10 @@ final class RankingForAllViewController: UIViewController {
 
     private func registerModel() {
       _ = model.notificationCenter
-               .addObserver(forName: .init(rawValue: "ranking"),
-                            object: nil, queue: nil) { [weak self] notification in
-                               if let ranking = notification.userInfo?["ranking"] as? Ranking {
-                                   self?.printData(ranking: ranking)
+            .addObserver(forName: .init(rawValue: Const.notificationName),
+                            object: nil, queue: nil) { notification in
+                               if let ranking = notification.userInfo?[Const.notificationName] as? Ranking {
+                                   ranking.printData()
                                }
       }
     }
@@ -34,12 +34,5 @@ final class RankingForAllViewController: UIViewController {
         
         model = RankingModel(apiClient: DefaultAPIClient.shared)
         model.requestRanking()
-    }
-    
-    private func printData(ranking: Ranking) {
-        for itemElement in ranking.items {
-            let item = itemElement.item
-            print("商品名: \(item.itemName)")
-        }
     }
 }

--- a/rakuten_ranking_app/Views/RankingForAllViewController.swift
+++ b/rakuten_ranking_app/Views/RankingForAllViewController.swift
@@ -32,7 +32,7 @@ class RankingForAllViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        model = RankingModel(apiClient: DefaultAPIClient.shared)
+        model = RankingModel(sex: .all, apiClient: DefaultAPIClient.shared)
         model.requestRanking()
     }
 }

--- a/rakuten_ranking_app/Views/RankingForFemaleViewController.swift
+++ b/rakuten_ranking_app/Views/RankingForFemaleViewController.swift
@@ -21,7 +21,7 @@ class RankingForFemaleViewController: UIViewController {
 
     private func registerModel() {
       _ = model.notificationCenter
-               .addObserver(forName: .init(rawValue: "ranking"),
+               .addObserver(forName: .init(rawValue: Const.notificationName),
                             object: nil, queue: nil) { [weak self] notification in
                                if let ranking = notification.userInfo?["ranking"] as? Ranking {
                                    self?.printData(ranking: ranking)
@@ -32,7 +32,7 @@ class RankingForFemaleViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        model = RankingModel(sex:2,apiClient: DefaultAPIClient.shared)
+        model = RankingModel(sex: 2, apiClient: DefaultAPIClient.shared)
         model.requestRanking()
     }
     

--- a/rakuten_ranking_app/Views/RankingForFemaleViewController.swift
+++ b/rakuten_ranking_app/Views/RankingForFemaleViewController.swift
@@ -22,9 +22,9 @@ class RankingForFemaleViewController: UIViewController {
     private func registerModel() {
       _ = model.notificationCenter
                .addObserver(forName: .init(rawValue: NotificationConst.rankingNotificationName),
-                            object: nil, queue: nil) { [weak self] notification in
+                            object: nil, queue: nil) { notification in
                                if let ranking = notification.userInfo?[NotificationConst.rankingNotificationName] as? Ranking {
-                                   self?.printData(ranking: ranking)
+                                   ranking.printData()
                                }
       }
     }
@@ -34,12 +34,5 @@ class RankingForFemaleViewController: UIViewController {
         
         model = RankingModel(sex: .female, apiClient: DefaultAPIClient.shared)
         model.requestRanking()
-    }
-    
-    private func printData(ranking: Ranking) {
-        for itemElement in ranking.items {
-              let item = itemElement.item
-              print("商品名: \(item.itemName)")
-          }
     }
 }

--- a/rakuten_ranking_app/Views/RankingForFemaleViewController.swift
+++ b/rakuten_ranking_app/Views/RankingForFemaleViewController.swift
@@ -8,9 +8,38 @@
 import UIKit
 
 class RankingForFemaleViewController: UIViewController {
+    
+    var model: RankingModel! {
+      didSet {
+        registerModel()
+      }
+    }
+    
+    deinit {
+      model.notificationCenter.removeObserver(self)
+    }
 
+    private func registerModel() {
+      _ = model.notificationCenter
+               .addObserver(forName: .init(rawValue: "ranking"),
+                            object: nil, queue: nil) { [weak self] notification in
+                               if let ranking = notification.userInfo?["ranking"] as? Ranking {
+                                   self?.printData(ranking: ranking)
+                               }
+      }
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        model = RankingModel(sex:2,apiClient: DefaultAPIClient.shared)
+        model.requestRanking()
+    }
+    
+    private func printData(ranking: Ranking) {
+        for itemElement in ranking.items {
+              let item = itemElement.item
+              print("商品名: \(item.itemName)")
+          }
     }
 }

--- a/rakuten_ranking_app/Views/RankingForFemaleViewController.swift
+++ b/rakuten_ranking_app/Views/RankingForFemaleViewController.swift
@@ -21,9 +21,9 @@ class RankingForFemaleViewController: UIViewController {
 
     private func registerModel() {
       _ = model.notificationCenter
-               .addObserver(forName: .init(rawValue: Const.notificationName),
+               .addObserver(forName: .init(rawValue: NotificationConst.rankingNotificationName),
                             object: nil, queue: nil) { [weak self] notification in
-                               if let ranking = notification.userInfo?["ranking"] as? Ranking {
+                               if let ranking = notification.userInfo?[NotificationConst.rankingNotificationName] as? Ranking {
                                    self?.printData(ranking: ranking)
                                }
       }

--- a/rakuten_ranking_app/Views/RankingForFemaleViewController.swift
+++ b/rakuten_ranking_app/Views/RankingForFemaleViewController.swift
@@ -32,7 +32,7 @@ class RankingForFemaleViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        model = RankingModel(sex: 2, apiClient: DefaultAPIClient.shared)
+        model = RankingModel(sex: .female, apiClient: DefaultAPIClient.shared)
         model.requestRanking()
     }
     

--- a/rakuten_ranking_app/Views/RankingForMaleViewController.swift
+++ b/rakuten_ranking_app/Views/RankingForMaleViewController.swift
@@ -31,7 +31,7 @@ class RankingForMaleViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        model = RankingModel(sex: 1, apiClient: DefaultAPIClient.shared)
+        model = RankingModel(sex: .male, apiClient: DefaultAPIClient.shared)
         model.requestRanking()
     }
     

--- a/rakuten_ranking_app/Views/RankingForMaleViewController.swift
+++ b/rakuten_ranking_app/Views/RankingForMaleViewController.swift
@@ -20,7 +20,7 @@ class RankingForMaleViewController: UIViewController {
     
     private func registerModel() {
       _ = model.notificationCenter
-               .addObserver(forName: .init(rawValue: "ranking"),
+            .addObserver(forName: .init(rawValue: Const.notificationName),
                             object: nil, queue: nil) { [weak self] notification in
                                if let ranking = notification.userInfo?["ranking"] as? Ranking {
                                    self?.printData(ranking: ranking)
@@ -31,7 +31,7 @@ class RankingForMaleViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        model = RankingModel(sex:1, apiClient: DefaultAPIClient.shared)
+        model = RankingModel(sex: 1, apiClient: DefaultAPIClient.shared)
         model.requestRanking()
     }
     

--- a/rakuten_ranking_app/Views/RankingForMaleViewController.swift
+++ b/rakuten_ranking_app/Views/RankingForMaleViewController.swift
@@ -21,9 +21,9 @@ class RankingForMaleViewController: UIViewController {
     private func registerModel() {
       _ = model.notificationCenter
             .addObserver(forName: .init(rawValue: NotificationConst.rankingNotificationName),
-                            object: nil, queue: nil) { [weak self] notification in
+                            object: nil, queue: nil) { notification in
                                if let ranking = notification.userInfo?[NotificationConst.rankingNotificationName] as? Ranking {
-                                   self?.printData(ranking: ranking)
+                                   ranking.printData()
                                }
       }
     }
@@ -33,12 +33,5 @@ class RankingForMaleViewController: UIViewController {
 
         model = RankingModel(sex: .male, apiClient: DefaultAPIClient.shared)
         model.requestRanking()
-    }
-    
-    private func printData(ranking: Ranking) {
-        for itemElement in ranking.items {
-              let item = itemElement.item
-              print("商品名: \(item.itemName)")
-          }
     }
 }

--- a/rakuten_ranking_app/Views/RankingForMaleViewController.swift
+++ b/rakuten_ranking_app/Views/RankingForMaleViewController.swift
@@ -8,9 +8,37 @@
 import UIKit
 
 class RankingForMaleViewController: UIViewController {
-
+    var model: RankingModel! {
+      didSet {
+        registerModel()
+      }
+    }
+    
+    deinit {
+      model.notificationCenter.removeObserver(self)
+    }
+    
+    private func registerModel() {
+      _ = model.notificationCenter
+               .addObserver(forName: .init(rawValue: "ranking"),
+                            object: nil, queue: nil) { [weak self] notification in
+                               if let ranking = notification.userInfo?["ranking"] as? Ranking {
+                                   self?.printData(ranking: ranking)
+                               }
+      }
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        model = RankingModel(sex:1, apiClient: DefaultAPIClient.shared)
+        model.requestRanking()
+    }
+    
+    private func printData(ranking: Ranking) {
+        for itemElement in ranking.items {
+              let item = itemElement.item
+              print("商品名: \(item.itemName)")
+          }
     }
 }

--- a/rakuten_ranking_app/Views/RankingForMaleViewController.swift
+++ b/rakuten_ranking_app/Views/RankingForMaleViewController.swift
@@ -20,9 +20,9 @@ class RankingForMaleViewController: UIViewController {
     
     private func registerModel() {
       _ = model.notificationCenter
-            .addObserver(forName: .init(rawValue: Const.notificationName),
+            .addObserver(forName: .init(rawValue: NotificationConst.rankingNotificationName),
                             object: nil, queue: nil) { [weak self] notification in
-                               if let ranking = notification.userInfo?["ranking"] as? Ranking {
+                               if let ranking = notification.userInfo?[NotificationConst.rankingNotificationName] as? Ranking {
                                    self?.printData(ranking: ranking)
                                }
       }

--- a/rakuten_ranking_app/Views/RankingPageViewController.swift
+++ b/rakuten_ranking_app/Views/RankingPageViewController.swift
@@ -7,15 +7,12 @@
 
 import UIKit
 
-//VCをスワイプするとTabを変えるdelegateの設定のためにprotocolを設定
 protocol RankingPageViewControllerDelegate: AnyObject {
-    //pageVCがスワイプによって切り替わった後、セグメントを更新する
     func changeTabByViewController(at index: Int)
 }
 
 class RankingPageViewController: UIPageViewController,UIPageViewControllerDelegate {
     weak var updateTabNotificationDelegate: RankingPageViewControllerDelegate?
-    //↑RankingPageViewControllerがページ遷移を完了した時にセグメントの状態を更新するためにRankingViewControllerに通知を送る役割をしている
             
     private var controllers: [UIViewController] = []
 
@@ -34,17 +31,14 @@ class RankingPageViewController: UIPageViewController,UIPageViewControllerDelega
             print("エラー:storyboardからViewControllerの取得に失敗")
             return
         }
-        //controllers配列に追加
         self.controllers = [rankingForAllVC, rankingForMaleVC, rankingForFemaleVC]
             
         if !controllers.isEmpty {
-            //最初のビューコントローラをセット
             setViewControllers([controllers[0]], direction: .forward, animated: true, completion: nil)
             self.dataSource = self
         }
     }
     
-    //ページ遷移が完了したらデリゲートメソッド
     func pageViewController(_ pageViewController: UIPageViewController, didFinishAnimating finished: Bool, previousViewControllers: [UIViewController], transitionCompleted completed: Bool) {
             if completed, let visibleViewController = viewControllers?.first, let index = controllers.firstIndex(of: visibleViewController) {
                 updateTabNotificationDelegate?.changeTabByViewController(at: index)
@@ -75,12 +69,9 @@ extension RankingPageViewController: UIPageViewControllerDataSource {
             return nil
         }
     }
-    
-    //指定されたインデックスに基づいて特定のビューコントローラを表示
+
     func switchToViewController(at index: Int) {
-       //配列の範囲外へのアクセスを防ぐ
        if index >= 0 && index < controllers.count {
-         //表示するビューコントローラーを設定:選択されたインデックスのVCを抽出し、そのVCを現在表示するように設定
          setViewControllers([controllers[index]], direction: .forward, animated: false, completion: nil)
        }
     }

--- a/rakuten_ranking_app/Views/RankingViewController.swift
+++ b/rakuten_ranking_app/Views/RankingViewController.swift
@@ -8,7 +8,6 @@
 import UIKit
 
 
-//選択されたタブに応じて表示するビューコントローラを変更するためのデリゲート
 protocol RankingViewControllerDelegate: AnyObject {
     func changeViewControllerByTab(at index: Int)
 }
@@ -16,27 +15,23 @@ protocol RankingViewControllerDelegate: AnyObject {
 class RankingViewController: UIViewController, UIPageViewControllerDelegate, RankingPageViewControllerDelegate {
     
     @IBOutlet weak var switchedView: UIView!
-    //segmentedControlの紐付け
     @IBOutlet weak var segmentedControl: UISegmentedControl!
     
     private var rankingPageViewController: RankingPageViewController?
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        //わかりやすい様に切り分ける
         setupPageViewController()
         setupSegmentedControl()
     }
     
     private func setupPageViewController() {
-        //ストーリーボードからRankingPageViewControllerをインスタンス化
         guard let rankingPageViewController = storyboard?.instantiateViewController(withIdentifier: "rankingPageViewController") as? RankingPageViewController else {
             print("StoryboardからRankingPageViewControllerのインスタンス化に失敗しました")
             return
         }
         
         addChild(rankingPageViewController)
-        //switchedViewに追加
         guard let switchedView = switchedView else {
             print("switchedViewがStoryboardで正しく接続されていません。")
             return
@@ -47,10 +42,9 @@ class RankingViewController: UIViewController, UIPageViewControllerDelegate, Ran
         rankingPageViewController.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         rankingPageViewController.didMove(toParent: self)
         self.rankingPageViewController = rankingPageViewController
-        //デリゲート
         rankingPageViewController.updateTabNotificationDelegate = self
     }
-    //セグメントコントロールを設定
+
     private func setupSegmentedControl() {
          guard let segmentedControl = segmentedControl else {
              print("segmentedControlがStoryboardで正しく接続されていません。")
@@ -65,12 +59,10 @@ class RankingViewController: UIViewController, UIPageViewControllerDelegate, Ran
          segmentedControl.addTarget(self, action: #selector(segmentChanged(_:)), for: .valueChanged)
      }
     
-    //タップされたときに呼び出されるアクション
     @objc private func segmentChanged(_ sender: UISegmentedControl) {
         rankingPageViewController?.switchToViewController(at: sender.selectedSegmentIndex)
     }
     
-    //ビューコントローラがスワイプで変更されたときにセグメントの選択を更新
     func changeTabByViewController(at index: Int) {
         segmentedControl?.selectedSegmentIndex = index
     }

--- a/rakuten_ranking_app/constants.swift
+++ b/rakuten_ranking_app/constants.swift
@@ -1,0 +1,14 @@
+//
+//  constants.swift
+//  rakuten_ranking_app
+//
+//  Created by 櫻田龍之助 on 2024/05/15.
+//
+
+import Foundation
+
+//ここで固定値を定義し渡す
+struct const {
+    static let baseURL = "https://app.rakuten.co.jp/services/api/"
+    static let urlPath = "IchibaItem/Ranking/20220601?applicationId=1054850339030324271"
+}

--- a/rakuten_ranking_app/constants.swift
+++ b/rakuten_ranking_app/constants.swift
@@ -10,5 +10,6 @@ import Foundation
 //ここで固定値を定義し渡す
 struct const {
     static let baseURL = "https://app.rakuten.co.jp/services/api/"
-    static let urlPath = "IchibaItem/Ranking/20220601?applicationId=1054850339030324271"
+    static let applicationId = "1054850339030324271"
+    static let urlPath = "IchibaItem/Ranking/20220601?applicationId=\(applicationId)"
 }

--- a/rakuten_ranking_app/constants.swift
+++ b/rakuten_ranking_app/constants.swift
@@ -11,5 +11,8 @@ import Foundation
 struct const {
     static let baseURL = "https://app.rakuten.co.jp/services/api/"
     static let applicationId = "1054850339030324271"
-    static let urlPath = "IchibaItem/Ranking/20220601?applicationId=\(applicationId)"
+    //APIリクエストURLで?applicationId が2回出現している　↓修正
+    static let urlPath = "IchibaItem/Ranking/20220601"
 }
+
+


### PR DESCRIPTION
## 概要

総合/男性/女性の切り替えをしAPIからデータ取得できるように実装しました。
enumのintで管理し、モデルのインスタンス作成時下記の様にすることでデータ取得可能
```model = RankingModel(sex:1, apiClient: DefaultAPIClient.shared)```
(この場合は男性)
