### PR TITLE
検索結果の30件をリスト形式で表示

### DIFF
--- a/rakuten_ranking_app.xcodeproj/project.pbxproj
+++ b/rakuten_ranking_app.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		6D275D8F2C057D330012750B /* SearchAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D275D8E2C057D330012750B /* SearchAPI.swift */; };
 		6D5245562BFF3E4F0045289D /* more_2_line.svg in Resources */ = {isa = PBXBuildFile; fileRef = 6D5245552BFF3E4F0045289D /* more_2_line.svg */; };
 		6D5245642C0073A90045289D /* Search.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D5245632C0073A90045289D /* Search.swift */; };
 		6D5245662C007A2B0045289D /* SearchModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D5245652C007A2B0045289D /* SearchModel.swift */; };
@@ -40,8 +39,8 @@
 		6DAFB3ED2BF753E30092F9BC /* RankingTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DAFB3EC2BF753E30092F9BC /* RankingTableViewCell.swift */; };
 		6DAFB3F12BFC69D30092F9BC /* PriceFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DAFB3F02BFC69D30092F9BC /* PriceFormatter.swift */; };
 		6DAFB3F32BFC69E20092F9BC /* ImageFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DAFB3F22BFC69E20092F9BC /* ImageFetcher.swift */; };
-		6DC193392C05684E00FFD1AD /* SearchAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DC193382C05684E00FFD1AD /* SearchAPI.swift */; };
 		6DC1933B2C05738F00FFD1AD /* SearchTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DC1933A2C05738F00FFD1AD /* SearchTableViewCell.swift */; };
+		6DF22AA62C07281E001B0654 /* SearchAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DF22AA52C07281E001B0654 /* SearchAPI.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -62,7 +61,6 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		6D275D8E2C057D330012750B /* SearchAPI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchAPI.swift; sourceTree = "<group>"; };
 		6D5245552BFF3E4F0045289D /* more_2_line.svg */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = more_2_line.svg; sourceTree = "<group>"; };
 		6D5245632C0073A90045289D /* Search.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Search.swift; sourceTree = "<group>"; };
 		6D5245652C007A2B0045289D /* SearchModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchModel.swift; sourceTree = "<group>"; };
@@ -95,8 +93,8 @@
 		6DAFB3EC2BF753E30092F9BC /* RankingTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RankingTableViewCell.swift; sourceTree = "<group>"; };
 		6DAFB3F02BFC69D30092F9BC /* PriceFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PriceFormatter.swift; sourceTree = "<group>"; };
 		6DAFB3F22BFC69E20092F9BC /* ImageFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageFetcher.swift; sourceTree = "<group>"; };
-		6DC193382C05684E00FFD1AD /* SearchAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchAPI.swift; sourceTree = "<group>"; };
 		6DC1933A2C05738F00FFD1AD /* SearchTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchTableViewCell.swift; sourceTree = "<group>"; };
+		6DF22AA52C07281E001B0654 /* SearchAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchAPI.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -230,10 +228,9 @@
 		6D6782542BF2100C00423201 /* API */ = {
 			isa = PBXGroup;
 			children = (
-				6D275D8E2C057D330012750B /* SearchAPI.swift */,
 				6D6782552BF2107000423201 /* APIClient.swift */,
 				6D67825C2BF2111100423201 /* RankingAPI.swift */,
-				6DC193382C05684E00FFD1AD /* SearchAPI.swift */,
+				6DF22AA52C07281E001B0654 /* SearchAPI.swift */,
 			);
 			path = API;
 			sourceTree = "<group>";
@@ -407,7 +404,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6DC193392C05684E00FFD1AD /* SearchAPI.swift in Sources */,
 				6D67820D2BEB291700423201 /* BookmarkViewController.swift in Sources */,
 				6D5245682C00854E0045289D /* SearchedItemsViewController.swift in Sources */,
 				6D67820B2BEB290900423201 /* SearchViewController.swift in Sources */,
@@ -423,6 +419,7 @@
 				6DAFB3F12BFC69D30092F9BC /* PriceFormatter.swift in Sources */,
 				6D6782672BF4A6CF00423201 /* Constants.swift in Sources */,
 				6D6782132BEC69DB00423201 /* RankingForAllViewController.swift in Sources */,
+				6DF22AA62C07281E001B0654 /* SearchAPI.swift in Sources */,
 				6D5245642C0073A90045289D /* Search.swift in Sources */,
 				6D6781BC2BEA268000423201 /* SceneDelegate.swift in Sources */,
 				6D6782172BEC6A0900423201 /* RankingForFemaleViewController.swift in Sources */,

--- a/rakuten_ranking_app.xcodeproj/project.pbxproj
+++ b/rakuten_ranking_app.xcodeproj/project.pbxproj
@@ -39,6 +39,8 @@
 		6DAFB3ED2BF753E30092F9BC /* RankingTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DAFB3EC2BF753E30092F9BC /* RankingTableViewCell.swift */; };
 		6DAFB3F12BFC69D30092F9BC /* PriceFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DAFB3F02BFC69D30092F9BC /* PriceFormatter.swift */; };
 		6DAFB3F32BFC69E20092F9BC /* ImageFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DAFB3F22BFC69E20092F9BC /* ImageFetcher.swift */; };
+		6DC193392C05684E00FFD1AD /* SearchAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DC193382C05684E00FFD1AD /* SearchAPI.swift */; };
+		6DC1933B2C05738F00FFD1AD /* SearchTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DC1933A2C05738F00FFD1AD /* SearchTableViewCell.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -91,6 +93,8 @@
 		6DAFB3EC2BF753E30092F9BC /* RankingTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RankingTableViewCell.swift; sourceTree = "<group>"; };
 		6DAFB3F02BFC69D30092F9BC /* PriceFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PriceFormatter.swift; sourceTree = "<group>"; };
 		6DAFB3F22BFC69E20092F9BC /* ImageFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageFetcher.swift; sourceTree = "<group>"; };
+		6DC193382C05684E00FFD1AD /* SearchAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchAPI.swift; sourceTree = "<group>"; };
+		6DC1933A2C05738F00FFD1AD /* SearchTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchTableViewCell.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -198,6 +202,7 @@
 				6D6782162BEC6A0900423201 /* RankingForFemaleViewController.swift */,
 				6DAFB3EC2BF753E30092F9BC /* RankingTableViewCell.swift */,
 				6D5245672C00854E0045289D /* SearchedItemsViewController.swift */,
+				6DC1933A2C05738F00FFD1AD /* SearchTableViewCell.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -225,6 +230,7 @@
 			children = (
 				6D6782552BF2107000423201 /* APIClient.swift */,
 				6D67825C2BF2111100423201 /* RankingAPI.swift */,
+				6DC193382C05684E00FFD1AD /* SearchAPI.swift */,
 			);
 			path = API;
 			sourceTree = "<group>";
@@ -398,6 +404,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6DC193392C05684E00FFD1AD /* SearchAPI.swift in Sources */,
 				6D67820D2BEB291700423201 /* BookmarkViewController.swift in Sources */,
 				6D5245682C00854E0045289D /* SearchedItemsViewController.swift in Sources */,
 				6D67820B2BEB290900423201 /* SearchViewController.swift in Sources */,
@@ -405,6 +412,7 @@
 				6D5245662C007A2B0045289D /* SearchModel.swift in Sources */,
 				6DAFB3F32BFC69E20092F9BC /* ImageFetcher.swift in Sources */,
 				6D6782092BEB28FC00423201 /* RankingViewController.swift in Sources */,
+				6DC1933B2C05738F00FFD1AD /* SearchTableViewCell.swift in Sources */,
 				6D67820F2BEB2C3D00423201 /* TabBarController.swift in Sources */,
 				6D6782602BF2117400423201 /* RankingModel.swift in Sources */,
 				6D6781BA2BEA268000423201 /* AppDelegate.swift in Sources */,

--- a/rakuten_ranking_app.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/rakuten_ranking_app.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "4fbec9efde6a900cf2a498554b39c27b126a9330fb0a5649b008df65705ad0cd",
+  "originHash" : "0102e67e7ac16849a1dbae24f87aecacc5d219ec3025e00caf92d2943e47854f",
   "pins" : [
     {
       "identity" : "alamofire",

--- a/rakuten_ranking_app.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/rakuten_ranking_app.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "0102e67e7ac16849a1dbae24f87aecacc5d219ec3025e00caf92d2943e47854f",
+  "originHash" : "4fbec9efde6a900cf2a498554b39c27b126a9330fb0a5649b008df65705ad0cd",
   "pins" : [
     {
       "identity" : "alamofire",

--- a/rakuten_ranking_app/Base.lproj/Main.storyboard
+++ b/rakuten_ranking_app/Base.lproj/Main.storyboard
@@ -594,7 +594,7 @@
                                 <rect key="frame" x="0.0" y="59" width="393" height="543"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <prototypes>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="SearchCell" rowHeight="139" id="LhV-Z0-9YK">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="SearchCell" rowHeight="139" id="LhV-Z0-9YK" customClass="SearchTableViewCell" customModule="rakuten_ranking_app" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="50" width="393" height="139"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="LhV-Z0-9YK" id="5zY-2j-P40">
@@ -661,6 +661,12 @@
                                             </constraints>
                                         </tableViewCellContentView>
                                         <accessibility key="accessibilityConfiguration" identifier="SearchCell"/>
+                                        <connections>
+                                            <outlet property="imageView" destination="cHb-mU-k3b" id="c4C-up-6ZT"/>
+                                            <outlet property="priceLabel" destination="0K9-ZN-InN" id="IMh-rZ-OR6"/>
+                                            <outlet property="productImageView" destination="cHb-mU-k3b" id="ajh-Gm-y9P"/>
+                                            <outlet property="productNameLabel" destination="0K9-ZN-InN" id="h4s-7Q-ghW"/>
+                                        </connections>
                                     </tableViewCell>
                                 </prototypes>
                             </tableView>
@@ -688,7 +694,7 @@
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="systemGray6Color">
-            <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.94901960780000005" green="0.94901960780000005" blue="0.96862745100000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/rakuten_ranking_app/Base.lproj/Main.storyboard
+++ b/rakuten_ranking_app/Base.lproj/Main.storyboard
@@ -587,11 +587,11 @@
             <objects>
                 <viewController id="QZd-Cr-zFz" customClass="SearchedItemsViewController" customModule="rakuten_ranking_app" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="f24-Ty-sLP">
-                        <rect key="frame" x="0.0" y="0.0" width="393" height="636"/>
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="666"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="gzB-tx-gHm">
-                                <rect key="frame" x="0.0" y="59" width="393" height="543"/>
+                                <rect key="frame" x="0.0" y="59" width="393" height="573"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="SearchCell" rowHeight="142" id="LhV-Z0-9YK" customClass="SearchTableViewCell" customModule="rakuten_ranking_app" customModuleProvider="target">
@@ -619,8 +619,8 @@
                                                                 <constraint firstAttribute="height" constant="21.329999999999998" id="gS6-71-WLa"/>
                                                             </constraints>
                                                         </imageView>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Labjbjbjhvjvkjuyycyuyucyvycyucycyucyucyucyycycycyelvhvhvyhvyvyvyvyvy" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Onh-EQ-W0T" userLabel="Product Name Label">
-                                                            <rect key="frame" x="82" y="16" width="243" height="46"/>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ラベルが長文だった場合、二行に折り返しをしさらに余った部分は...で省略されます" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Onh-EQ-W0T" userLabel="Product Name Label">
+                                                            <rect key="frame" x="82" y="16" width="240" height="46"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="height" constant="46" id="SK6-BM-qha"/>
                                                             </constraints>

--- a/rakuten_ranking_app/Base.lproj/Main.storyboard
+++ b/rakuten_ranking_app/Base.lproj/Main.storyboard
@@ -682,6 +682,9 @@
                             <constraint firstItem="gzB-tx-gHm" firstAttribute="top" secondItem="Sib-kk-b0p" secondAttribute="top" id="lhV-ih-gWr"/>
                         </constraints>
                     </view>
+                    <connections>
+                        <outlet property="tableView" destination="gzB-tx-gHm" id="8OL-JO-SoB"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="pbI-OF-t4o" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>

--- a/rakuten_ranking_app/Base.lproj/Main.storyboard
+++ b/rakuten_ranking_app/Base.lproj/Main.storyboard
@@ -17,7 +17,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="H87-MW-8Yt">
-                                <rect key="frame" x="0.0" y="133" width="393" height="636"/>
+                                <rect key="frame" x="0.0" y="103" width="393" height="666"/>
                                 <connections>
                                     <segue destination="QZd-Cr-zFz" kind="embed" id="G9C-nq-pA4"/>
                                 </connections>
@@ -26,7 +26,7 @@
                         <viewLayoutGuide key="safeArea" id="R74-fg-Gdt"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="H87-MW-8Yt" firstAttribute="top" secondItem="R74-fg-Gdt" secondAttribute="top" constant="30" id="IZ4-5W-9fy"/>
+                            <constraint firstItem="H87-MW-8Yt" firstAttribute="top" secondItem="R74-fg-Gdt" secondAttribute="top" id="IZ4-5W-9fy"/>
                             <constraint firstItem="R74-fg-Gdt" firstAttribute="bottom" secondItem="H87-MW-8Yt" secondAttribute="bottom" id="R75-z9-0op"/>
                             <constraint firstItem="H87-MW-8Yt" firstAttribute="leading" secondItem="R74-fg-Gdt" secondAttribute="leading" id="UTn-eg-5qJ"/>
                             <constraint firstItem="R74-fg-Gdt" firstAttribute="trailing" secondItem="H87-MW-8Yt" secondAttribute="trailing" id="Xmi-C7-ivL"/>
@@ -620,7 +620,7 @@
                                                             </constraints>
                                                         </imageView>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Labjbjbjhvjvkjuyycyuyucyvycyucycyucyucyucyycycycyelvhvhvyhvyvyvyvyvy" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Onh-EQ-W0T" userLabel="Product Name Label">
-                                                            <rect key="frame" x="82" y="16" width="243" height="48"/>
+                                                            <rect key="frame" x="82" y="16" width="243" height="46"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="height" constant="46" id="SK6-BM-qha"/>
                                                             </constraints>
@@ -629,7 +629,7 @@
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0K9-ZN-InN">
-                                                            <rect key="frame" x="82" y="64" width="247" height="46"/>
+                                                            <rect key="frame" x="82" y="62" width="247" height="48"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="height" constant="46" id="ak7-v4-4KE"/>
                                                             </constraints>

--- a/rakuten_ranking_app/Base.lproj/Main.storyboard
+++ b/rakuten_ranking_app/Base.lproj/Main.storyboard
@@ -594,70 +594,71 @@
                                 <rect key="frame" x="0.0" y="59" width="393" height="543"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <prototypes>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="SearchCell" rowHeight="139" id="LhV-Z0-9YK" customClass="SearchTableViewCell" customModule="rakuten_ranking_app" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="50" width="393" height="139"/>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="SearchCell" rowHeight="142" id="LhV-Z0-9YK" customClass="SearchTableViewCell" customModule="rakuten_ranking_app" customModuleProvider="target">
+                                        <rect key="frame" x="0.0" y="50" width="393" height="142"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="LhV-Z0-9YK" id="5zY-2j-P40">
-                                            <rect key="frame" x="0.0" y="0.0" width="393" height="139"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="393" height="142"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="lv0-ex-xNW" userLabel="ViewForSpacing">
-                                                    <rect key="frame" x="16" y="8" width="361" height="123"/>
+                                                    <rect key="frame" x="16" y="8" width="361" height="126"/>
                                                     <subviews>
                                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="cHb-mU-k3b">
-                                                            <rect key="frame" x="10" y="29.666666666666664" width="64" height="63.999999999999993"/>
+                                                            <rect key="frame" x="10" y="31" width="64" height="64"/>
                                                             <constraints>
-                                                                <constraint firstAttribute="width" secondItem="cHb-mU-k3b" secondAttribute="height" multiplier="1:1" id="3Kf-dR-HLV"/>
-                                                                <constraint firstAttribute="width" constant="64" id="IHB-Iz-OGi"/>
-                                                                <constraint firstAttribute="height" constant="64" id="QMe-kL-lgx"/>
+                                                                <constraint firstAttribute="height" constant="64" id="27e-I8-fta"/>
+                                                                <constraint firstAttribute="width" constant="64" id="XNn-9S-CYC"/>
+                                                                <constraint firstAttribute="width" secondItem="cHb-mU-k3b" secondAttribute="height" multiplier="1:1" id="rq3-IX-2kE"/>
                                                             </constraints>
                                                         </imageView>
                                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" image="bookmark.fill" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="kF7-3x-w26">
-                                                            <rect key="frame" x="335" y="51.333333333333329" width="16" height="21"/>
+                                                            <rect key="frame" x="335" y="52.666666666666671" width="16" height="21"/>
                                                             <constraints>
-                                                                <constraint firstAttribute="height" constant="21.329999999999998" id="75n-Ta-hyV"/>
-                                                                <constraint firstAttribute="width" constant="16" id="79o-y1-9BC"/>
+                                                                <constraint firstAttribute="width" constant="16" id="aQj-DU-bKg"/>
+                                                                <constraint firstAttribute="height" constant="21.329999999999998" id="gS6-71-WLa"/>
                                                             </constraints>
                                                         </imageView>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0K9-ZN-InN">
-                                                            <rect key="frame" x="82" y="59" width="247" height="48"/>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Labjbjbjhvjvkjuyycyuyucyvycyucycyucyucyucyycycycyelvhvhvyhvyvyvyvyvy" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Onh-EQ-W0T" userLabel="Product Name Label">
+                                                            <rect key="frame" x="82" y="16" width="243" height="48"/>
                                                             <constraints>
-                                                                <constraint firstAttribute="height" constant="48" id="eXm-Tr-kB0"/>
+                                                                <constraint firstAttribute="height" constant="46" id="SK6-BM-qha"/>
                                                             </constraints>
-                                                            <fontDescription key="fontDescription" type="system" pointSize="32"/>
+                                                            <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                                             <nil key="textColor"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Onh-EQ-W0T">
-                                                            <rect key="frame" x="82" y="16" width="247" height="48"/>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0K9-ZN-InN">
+                                                            <rect key="frame" x="82" y="64" width="247" height="46"/>
                                                             <constraints>
-                                                                <constraint firstAttribute="height" constant="48" id="6zB-oV-Fzs"/>
+                                                                <constraint firstAttribute="height" constant="46" id="ak7-v4-4KE"/>
                                                             </constraints>
-                                                            <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                                            <fontDescription key="fontDescription" type="system" pointSize="32"/>
                                                             <nil key="textColor"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                     </subviews>
                                                     <color key="backgroundColor" systemColor="systemGray6Color"/>
                                                     <constraints>
-                                                        <constraint firstItem="Onh-EQ-W0T" firstAttribute="top" secondItem="lv0-ex-xNW" secondAttribute="top" constant="16" id="84u-LZ-04n"/>
-                                                        <constraint firstItem="kF7-3x-w26" firstAttribute="leading" secondItem="0K9-ZN-InN" secondAttribute="trailing" constant="6" id="Bp7-Oa-UkQ"/>
-                                                        <constraint firstAttribute="trailing" secondItem="kF7-3x-w26" secondAttribute="trailing" constant="10" id="EaB-WR-Lx7"/>
-                                                        <constraint firstItem="kF7-3x-w26" firstAttribute="leading" secondItem="Onh-EQ-W0T" secondAttribute="trailing" constant="6" id="I5C-dD-jnz"/>
-                                                        <constraint firstAttribute="bottom" secondItem="0K9-ZN-InN" secondAttribute="bottom" constant="16" id="VDo-Ns-i5d"/>
-                                                        <constraint firstItem="cHb-mU-k3b" firstAttribute="centerY" secondItem="lv0-ex-xNW" secondAttribute="centerY" id="WMc-La-IMo"/>
-                                                        <constraint firstItem="cHb-mU-k3b" firstAttribute="leading" secondItem="lv0-ex-xNW" secondAttribute="leading" constant="10" id="hNs-nU-VxP"/>
-                                                        <constraint firstItem="kF7-3x-w26" firstAttribute="centerY" secondItem="lv0-ex-xNW" secondAttribute="centerY" id="hgK-hW-Qi1"/>
-                                                        <constraint firstItem="0K9-ZN-InN" firstAttribute="leading" secondItem="cHb-mU-k3b" secondAttribute="trailing" constant="8" id="to3-SW-nYp"/>
-                                                        <constraint firstItem="Onh-EQ-W0T" firstAttribute="leading" secondItem="cHb-mU-k3b" secondAttribute="trailing" constant="8" id="vxJ-aX-rzr"/>
+                                                        <constraint firstItem="cHb-mU-k3b" firstAttribute="centerY" secondItem="lv0-ex-xNW" secondAttribute="centerY" id="4A4-ul-Xoi"/>
+                                                        <constraint firstItem="Onh-EQ-W0T" firstAttribute="top" secondItem="lv0-ex-xNW" secondAttribute="top" constant="16" id="7ac-F6-ARK"/>
+                                                        <constraint firstItem="cHb-mU-k3b" firstAttribute="leading" secondItem="lv0-ex-xNW" secondAttribute="leading" constant="10" id="C5k-7U-kl9"/>
+                                                        <constraint firstItem="0K9-ZN-InN" firstAttribute="top" secondItem="Onh-EQ-W0T" secondAttribute="bottom" id="K5c-d4-odP"/>
+                                                        <constraint firstItem="kF7-3x-w26" firstAttribute="leading" secondItem="0K9-ZN-InN" secondAttribute="trailing" constant="6" id="RaC-Ka-E2F"/>
+                                                        <constraint firstItem="0K9-ZN-InN" firstAttribute="leading" secondItem="cHb-mU-k3b" secondAttribute="trailing" constant="8" id="UcV-gb-qzK"/>
+                                                        <constraint firstItem="Onh-EQ-W0T" firstAttribute="leading" secondItem="cHb-mU-k3b" secondAttribute="trailing" constant="8" id="kYB-x0-7iS"/>
+                                                        <constraint firstItem="kF7-3x-w26" firstAttribute="centerY" secondItem="lv0-ex-xNW" secondAttribute="centerY" id="mx7-EU-W64"/>
+                                                        <constraint firstAttribute="bottom" secondItem="0K9-ZN-InN" secondAttribute="bottom" constant="16" id="o6Q-29-Srq"/>
+                                                        <constraint firstItem="kF7-3x-w26" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="Onh-EQ-W0T" secondAttribute="trailing" constant="6" id="r4Y-Be-7Gy"/>
+                                                        <constraint firstAttribute="trailing" secondItem="kF7-3x-w26" secondAttribute="trailing" constant="10" id="sCE-Ri-oTV"/>
                                                     </constraints>
                                                 </view>
                                             </subviews>
                                             <constraints>
-                                                <constraint firstItem="lv0-ex-xNW" firstAttribute="top" secondItem="5zY-2j-P40" secondAttribute="top" constant="8" id="KC1-3Q-ePH"/>
-                                                <constraint firstItem="lv0-ex-xNW" firstAttribute="leading" secondItem="5zY-2j-P40" secondAttribute="leading" constant="16" id="Pai-HB-RNa"/>
-                                                <constraint firstAttribute="bottom" secondItem="lv0-ex-xNW" secondAttribute="bottom" constant="8" id="UmP-1v-YIr"/>
-                                                <constraint firstAttribute="trailing" secondItem="lv0-ex-xNW" secondAttribute="trailing" constant="16" id="v4a-KV-kTJ"/>
+                                                <constraint firstAttribute="trailing" secondItem="lv0-ex-xNW" secondAttribute="trailing" constant="16" id="AOq-qM-Lkc"/>
+                                                <constraint firstAttribute="bottom" secondItem="lv0-ex-xNW" secondAttribute="bottom" constant="8" id="KgM-8C-sRa"/>
+                                                <constraint firstItem="lv0-ex-xNW" firstAttribute="leading" secondItem="5zY-2j-P40" secondAttribute="leading" constant="16" id="SfX-Vx-gEF"/>
+                                                <constraint firstItem="lv0-ex-xNW" firstAttribute="top" secondItem="5zY-2j-P40" secondAttribute="top" constant="8" id="v16-cL-YGI"/>
                                             </constraints>
                                         </tableViewCellContentView>
                                         <accessibility key="accessibilityConfiguration" identifier="SearchCell"/>
@@ -665,7 +666,7 @@
                                             <outlet property="imageView" destination="cHb-mU-k3b" id="c4C-up-6ZT"/>
                                             <outlet property="priceLabel" destination="0K9-ZN-InN" id="IMh-rZ-OR6"/>
                                             <outlet property="productImageView" destination="cHb-mU-k3b" id="ajh-Gm-y9P"/>
-                                            <outlet property="productNameLabel" destination="0K9-ZN-InN" id="h4s-7Q-ghW"/>
+                                            <outlet property="productNameLabel" destination="Onh-EQ-W0T" id="ZfO-JJ-1Gd"/>
                                         </connections>
                                     </tableViewCell>
                                 </prototypes>
@@ -676,10 +677,8 @@
                         <constraints>
                             <constraint firstItem="gzB-tx-gHm" firstAttribute="leading" secondItem="Sib-kk-b0p" secondAttribute="leading" id="L2P-h7-m2A"/>
                             <constraint firstItem="Sib-kk-b0p" firstAttribute="trailing" secondItem="gzB-tx-gHm" secondAttribute="trailing" id="QPs-zW-DY5"/>
-                            <constraint firstItem="gzB-tx-gHm" firstAttribute="trailing" secondItem="Sib-kk-b0p" secondAttribute="trailing" id="UUK-Yq-6Ow"/>
+                            <constraint firstItem="gzB-tx-gHm" firstAttribute="top" secondItem="Sib-kk-b0p" secondAttribute="top" id="VEl-X3-OV2"/>
                             <constraint firstItem="Sib-kk-b0p" firstAttribute="bottom" secondItem="gzB-tx-gHm" secondAttribute="bottom" id="jks-yj-p7F"/>
-                            <constraint firstItem="gzB-tx-gHm" firstAttribute="leading" secondItem="Sib-kk-b0p" secondAttribute="leading" id="jyf-yA-IMO"/>
-                            <constraint firstItem="gzB-tx-gHm" firstAttribute="top" secondItem="Sib-kk-b0p" secondAttribute="top" id="lhV-ih-gWr"/>
                         </constraints>
                     </view>
                     <connections>

--- a/rakuten_ranking_app/Base.lproj/Main.storyboard
+++ b/rakuten_ranking_app/Base.lproj/Main.storyboard
@@ -604,7 +604,7 @@
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="lv0-ex-xNW" userLabel="ViewForSpacing">
                                                     <rect key="frame" x="16" y="8" width="361" height="126"/>
                                                     <subviews>
-                                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="cHb-mU-k3b">
+                                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="cHb-mU-k3b" userLabel="Product Image View">
                                                             <rect key="frame" x="10" y="31" width="64" height="64"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="height" constant="64" id="27e-I8-fta"/>
@@ -640,12 +640,12 @@
                                                     </subviews>
                                                     <color key="backgroundColor" systemColor="systemGray6Color"/>
                                                     <constraints>
-                                                        <constraint firstItem="cHb-mU-k3b" firstAttribute="centerY" secondItem="lv0-ex-xNW" secondAttribute="centerY" id="4A4-ul-Xoi"/>
                                                         <constraint firstItem="Onh-EQ-W0T" firstAttribute="top" secondItem="lv0-ex-xNW" secondAttribute="top" constant="16" id="7ac-F6-ARK"/>
                                                         <constraint firstItem="cHb-mU-k3b" firstAttribute="leading" secondItem="lv0-ex-xNW" secondAttribute="leading" constant="10" id="C5k-7U-kl9"/>
                                                         <constraint firstItem="0K9-ZN-InN" firstAttribute="top" secondItem="Onh-EQ-W0T" secondAttribute="bottom" id="K5c-d4-odP"/>
                                                         <constraint firstItem="kF7-3x-w26" firstAttribute="leading" secondItem="0K9-ZN-InN" secondAttribute="trailing" constant="6" id="RaC-Ka-E2F"/>
                                                         <constraint firstItem="0K9-ZN-InN" firstAttribute="leading" secondItem="cHb-mU-k3b" secondAttribute="trailing" constant="8" id="UcV-gb-qzK"/>
+                                                        <constraint firstItem="cHb-mU-k3b" firstAttribute="centerY" secondItem="lv0-ex-xNW" secondAttribute="centerY" id="d4X-So-fVV"/>
                                                         <constraint firstItem="Onh-EQ-W0T" firstAttribute="leading" secondItem="cHb-mU-k3b" secondAttribute="trailing" constant="8" id="kYB-x0-7iS"/>
                                                         <constraint firstItem="kF7-3x-w26" firstAttribute="centerY" secondItem="lv0-ex-xNW" secondAttribute="centerY" id="mx7-EU-W64"/>
                                                         <constraint firstAttribute="bottom" secondItem="0K9-ZN-InN" secondAttribute="bottom" constant="16" id="o6Q-29-Srq"/>
@@ -663,7 +663,6 @@
                                         </tableViewCellContentView>
                                         <accessibility key="accessibilityConfiguration" identifier="SearchCell"/>
                                         <connections>
-                                            <outlet property="imageView" destination="cHb-mU-k3b" id="c4C-up-6ZT"/>
                                             <outlet property="priceLabel" destination="0K9-ZN-InN" id="IMh-rZ-OR6"/>
                                             <outlet property="productImageView" destination="cHb-mU-k3b" id="ajh-Gm-y9P"/>
                                             <outlet property="productNameLabel" destination="Onh-EQ-W0T" id="ZfO-JJ-1Gd"/>

--- a/rakuten_ranking_app/Models/API/SearchAPI.swift
+++ b/rakuten_ranking_app/Models/API/SearchAPI.swift
@@ -2,18 +2,18 @@
 //  SearchAPI.swift
 //  rakuten_ranking_app
 //
-//  Created by 櫻田龍之助 on 2024/05/28.
+//  Created by 櫻田龍之助 on 2024/05/29.
 //
 
 import Foundation
 
-//APIクライアントを通じて検索データを取得す
+// APIクライアントを通じて検索データを取得す
 class SearchAPI{
     private let apiClient: APIClient
-
-    //apiClientを初期化
+    
+    // apiClientを初期化
     init(apiClient: APIClient) {
-      self.apiClient = apiClient
+        self.apiClient = apiClient
     }
     
     func requestSearch(keyword: String, completion: @escaping (Result<Search, APIError>) -> Void) {
@@ -46,9 +46,9 @@ extension SearchRequest {
 }
 
 enum SearchAPIRequest: SearchRequest {
-    //キーワードを受け取り、それに応じたリクエストを作成
+    // キーワードを受け取り、それに応じたリクエストを作成
     case getSearch(keyword: String)
-
+    
     public var parameters: [String: Any] {
         switch self {
         case .getSearch(let keyword):

--- a/rakuten_ranking_app/Models/DataManagement/SearchModel.swift
+++ b/rakuten_ranking_app/Models/DataManagement/SearchModel.swift
@@ -24,9 +24,6 @@ class SearchModel {
                     object: nil,
                     userInfo: userInfo.isEmpty ? nil : userInfo
                 )
-                       
-                // 検索結果の最初の30件をコンソールに表示
-                printSearchResults(validSearch)
             }
         }
     }
@@ -37,7 +34,6 @@ class SearchModel {
     
     //検索バーで取得した文字をSearchedItemsViewControllerから受け取る
     func fetchSearchResults(with searchText: String) {
-        print("次の検索文字列をモデルで受け取った: \(searchText)")
         // SearchAPIを使って検索を行う
         let searchAPI = SearchAPI(apiClient: apiClient)
         searchAPI.requestSearch(keyword: searchText) { [weak self] result in
@@ -48,14 +44,4 @@ class SearchModel {
             }
         }
     }
-    
-    //検索結果をコンソールに表示するメソッド (30件)
-    private func printSearchResults(_ search: Search) {
-          let items = search.items.prefix(30)
-          for item in items {
-              let name = item.item.itemName
-              let price = item.item.itemPrice
-              print("商品名: \(name), 価格: \(price)")
-          }
-      }
 }

--- a/rakuten_ranking_app/Models/DataManagement/SearchModel.swift
+++ b/rakuten_ranking_app/Models/DataManagement/SearchModel.swift
@@ -11,12 +11,12 @@ class SearchModel {
     let notificationCenter = NotificationCenter.default
     private let apiClient: APIClient
     
-    //取得したSearchデータを保持
+    // 取得したSearchデータを保持
     private(set) var search: Search? {
         didSet {
-            //通知に用いる追加情報を格納するための空のuserInfo辞書を初期化
+            // 通知に用いる追加情報を格納するための空のuserInfo辞書を初期化
             var userInfo: [String: Any] = [:]
-            //searchプロパティがnilでないかをチェック
+            // searchプロパティがnilでないかをチェック
             if let validSearch = search {
                 userInfo[NotificationConst.UserInfoKeysForSearch.search] = validSearch
                 notificationCenter.post(
@@ -29,17 +29,17 @@ class SearchModel {
     }
     
     init(apiClient: APIClient) {
-       self.apiClient = apiClient
+        self.apiClient = apiClient
     }
     
-    //検索バーで取得した文字をSearchedItemsViewControllerから受け取る
+    /// 検索バーで取得した文字をSearchedItemsViewControllerから受け取る
     func fetchSearchResults(with searchText: String) {
         // SearchAPIを使って検索を行う
         let searchAPI = SearchAPI(apiClient: apiClient)
         searchAPI.requestSearch(keyword: searchText) { [weak self] result in
             DispatchQueue.main.async {
                 if case .success(let search) = result {
-                   self?.search = search
+                    self?.search = search
                 }
             }
         }

--- a/rakuten_ranking_app/Models/DataManagement/SearchModel.swift
+++ b/rakuten_ranking_app/Models/DataManagement/SearchModel.swift
@@ -19,12 +19,15 @@ class SearchModel {
             //searchプロパティがnilでないかをチェック
             if let validSearch = search {
                 userInfo[NotificationConst.UserInfoKeysForSearch.search] = validSearch
+                notificationCenter.post(
+                    name: .init(rawValue: NotificationConst.searchNotificationName),
+                    object: nil,
+                    userInfo: userInfo.isEmpty ? nil : userInfo
+                )
+                       
+                // 検索結果の最初の30件をコンソールに表示
+                printSearchResults(validSearch)
             }
-            notificationCenter.post(
-                name: .init(rawValue: NotificationConst.searchNotificationName),
-                object: nil,
-                userInfo: userInfo.isEmpty ? nil : userInfo
-            )
         }
     }
     
@@ -39,15 +42,20 @@ class SearchModel {
         let searchAPI = SearchAPI(apiClient: apiClient)
         searchAPI.requestSearch(keyword: searchText) { [weak self] result in
             DispatchQueue.main.async {
-                switch result {
-                case .success(let searchResults):
-                    self?.search = searchResults
-                    print("検索結果を取得しました。")
-                case .failure(let error):
-                    print("検索に失敗しました: \(error)")
-                    self?.search = nil
+                if case .success(let search) = result {
+                   self?.search = search
                 }
             }
         }
     }
+    
+    //検索結果をコンソールに表示するメソッド (30件)
+    private func printSearchResults(_ search: Search) {
+          let items = search.items.prefix(30)
+          for item in items {
+              let name = item.item.itemName
+              let price = item.item.itemPrice
+              print("商品名: \(name), 価格: \(price)")
+          }
+      }
 }

--- a/rakuten_ranking_app/Models/DataManagement/SearchModel.swift
+++ b/rakuten_ranking_app/Models/DataManagement/SearchModel.swift
@@ -9,6 +9,7 @@ import Foundation
 
 class SearchModel {
     let notificationCenter = NotificationCenter.default
+    private let apiClient: APIClient
     
     //取得したSearchデータを保持
     private(set) var search: Search? {
@@ -27,8 +28,26 @@ class SearchModel {
         }
     }
     
+    init(apiClient: APIClient) {
+       self.apiClient = apiClient
+    }
+    
     //検索バーで取得した文字をSearchedItemsViewControllerから受け取る
     func fetchSearchResults(with searchText: String) {
         print("次の検索文字列をモデルで受け取った: \(searchText)")
+        // SearchAPIを使って検索を行う
+        let searchAPI = SearchAPI(apiClient: apiClient)
+        searchAPI.requestSearch(keyword: searchText) { [weak self] result in
+            DispatchQueue.main.async {
+                switch result {
+                case .success(let searchResults):
+                    self?.search = searchResults
+                    print("検索結果を取得しました。")
+                case .failure(let error):
+                    print("検索に失敗しました: \(error)")
+                    self?.search = nil
+                }
+            }
+        }
     }
 }

--- a/rakuten_ranking_app/Models/JSONExport/Search.swift
+++ b/rakuten_ranking_app/Models/JSONExport/Search.swift
@@ -10,12 +10,12 @@ import Foundation
 struct Search: Codable {
     let genreInformation: [GenreInformation]
     let items: [SearchItemElement]
-
+    
     enum CodingKeys: String, CodingKey {
         case genreInformation = "GenreInformation"
         case items = "Items"
     }
-
+    
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         genreInformation = try container.decode([GenreInformation].self, forKey: .genreInformation)
@@ -25,7 +25,7 @@ struct Search: Codable {
 
 struct SearchItemElement: Codable {
     let item: SearchItem
-
+    
     enum CodingKeys: String, CodingKey {
         case item = "Item"
     }

--- a/rakuten_ranking_app/Views/SearchTableViewCell.swift
+++ b/rakuten_ranking_app/Views/SearchTableViewCell.swift
@@ -18,11 +18,11 @@ class SearchTableViewCell: UITableViewCell {
         productImageView.image = nil
         
         if let urlString = item.mediumImageUrls.first?.imageUrl {
-          ImageFetcher.fetchImage(from: urlString) { [weak self] image in
-              DispatchQueue.main.async {
-                 self?.productImageView.image = image
-              }
-          }
+            ImageFetcher.fetchImage(from: urlString) { [weak self] image in
+                DispatchQueue.main.async {
+                    self?.productImageView.image = image
+                }
+            }
         }
     }
 }

--- a/rakuten_ranking_app/Views/SearchTableViewCell.swift
+++ b/rakuten_ranking_app/Views/SearchTableViewCell.swift
@@ -1,0 +1,26 @@
+//
+//  SearchTableViewCell.swift
+//  rakuten_ranking_app
+//
+//  Created by 櫻田龍之助 on 2024/05/28.
+//
+
+import UIKit
+
+class SearchTableViewCell: UITableViewCell {
+    @IBOutlet weak var productImageView: UIImageView!
+    @IBOutlet weak var productNameLabel: UILabel!
+    @IBOutlet weak var priceLabel: UILabel!
+    
+    func configure(with item: SearchItem, at indexPath: IndexPath, in tableView: UITableView) {
+          productNameLabel.text = item.itemName
+          priceLabel.text = PriceFormatter.formatPrice(String(item.itemPrice))
+          ImageFetcher.fetchImage(from: item.mediumImageUrls.first?.imageUrl ?? "") { [weak self] image in
+              DispatchQueue.main.async {
+                  if tableView.cellForRow(at: indexPath) == self {
+                      self?.productImageView.image = image
+                  }
+              }
+          }
+    }
+}

--- a/rakuten_ranking_app/Views/SearchTableViewCell.swift
+++ b/rakuten_ranking_app/Views/SearchTableViewCell.swift
@@ -9,18 +9,20 @@ import UIKit
 
 class SearchTableViewCell: UITableViewCell {
     @IBOutlet weak var productImageView: UIImageView!
-    @IBOutlet weak var productNameLabel: UILabel!
     @IBOutlet weak var priceLabel: UILabel!
+    @IBOutlet weak var productNameLabel: UILabel!
     
     func configure(with item: SearchItem, at indexPath: IndexPath, in tableView: UITableView) {
-          productNameLabel.text = item.itemName
-          priceLabel.text = PriceFormatter.formatPrice(String(item.itemPrice))
-          ImageFetcher.fetchImage(from: item.mediumImageUrls.first?.imageUrl ?? "") { [weak self] image in
+        productNameLabel.text = item.itemName
+        priceLabel.text = PriceFormatter.formatPrice(String(item.itemPrice))
+        productImageView.image = nil
+        
+        if let urlString = item.mediumImageUrls.first?.imageUrl {
+          ImageFetcher.fetchImage(from: urlString) { [weak self] image in
               DispatchQueue.main.async {
-                  if tableView.cellForRow(at: indexPath) == self {
-                      self?.productImageView.image = image
-                  }
+                 self?.productImageView.image = image
               }
           }
+        }
     }
 }

--- a/rakuten_ranking_app/Views/SearchViewController.swift
+++ b/rakuten_ranking_app/Views/SearchViewController.swift
@@ -19,8 +19,8 @@ class SearchViewController: UIViewController,UISearchBarDelegate  {
         setupSearchBar()
         addEllipsisButton()
     }
-
-    ///searchBarをNavigationBarに設置する関数
+    
+    /// searchBarをNavigationBarに設置する関数
     func setupSearchBar() {
         if let navigationBarFrame = navigationController?.navigationBar.bounds {
             let searchBar = UISearchBar(frame: navigationBarFrame)
@@ -31,22 +31,22 @@ class SearchViewController: UIViewController,UISearchBarDelegate  {
             navigationItem.titleView = searchBar
             self.searchBar = searchBar
         }
-     }
+    }
     
-    ///SVGファイルを使用してNavigationBarにボタンを追加するための処理
+    /// SVGファイルを使用してNavigationBarにボタンを追加するための処理
     func addEllipsisButton() {
         guard let filePath = Bundle.main.path(forResource: "more_2_line", ofType: "svg") else {
             print("SVG画像が見つからない")
             return
         }
-        //ライブラリのバグで、最初一回のSVG読み込みに失敗してしまうのを回避するためのコード
+        // ライブラリのバグで、最初一回のSVG読み込みに失敗してしまうのを回避するためのコード
         _ = SVGKImage(contentsOfFile: filePath)?.uiImage
         let svgImage = SVGKImage(contentsOfFile: filePath)?.uiImage
         let ellipsisButton = UIBarButtonItem(image: svgImage, style: .plain, target: self, action: #selector(self.ellipsisButtonTapped))
         self.navigationItem.rightBarButtonItem = ellipsisButton
     }
-
-
+    
+    
     @objc func ellipsisButtonTapped() {
         print("elliipsがタップされました")
     }

--- a/rakuten_ranking_app/Views/SearchedItemsViewController.swift
+++ b/rakuten_ranking_app/Views/SearchedItemsViewController.swift
@@ -13,9 +13,9 @@ class SearchedItemsViewController:UIViewController, UISearchBarDelegate, UITable
     var searchString: String?
     
     var model: SearchModel?{
-      didSet {
-        registerModel()
-      }
+        didSet {
+            registerModel()
+        }
     }
     
     @IBOutlet weak var tableView: UITableView!
@@ -23,12 +23,12 @@ class SearchedItemsViewController:UIViewController, UISearchBarDelegate, UITable
     private var items: [SearchItemElement] = []
     
     deinit {
-      model?.notificationCenter.removeObserver(self)
+        model?.notificationCenter.removeObserver(self)
     }
     
     private func registerModel() {
         _ = model?.notificationCenter.addObserver(forName: .init(rawValue: NotificationConst.searchNotificationName),
-                                              object: nil, queue: nil) { [weak self] notification in
+                                                  object: nil, queue: nil) { [weak self] notification in
             if let search = notification.userInfo?[NotificationConst.UserInfoKeysForSearch.search] as? Search {
                 self?.items = search.items
                 self?.tableView.reloadData()
@@ -38,7 +38,7 @@ class SearchedItemsViewController:UIViewController, UISearchBarDelegate, UITable
     
     override func viewDidLoad() {
         super.viewDidLoad()
-      
+        
         tableView.dataSource = self
         tableView.delegate = self
         tableView.separatorStyle = .none
@@ -51,7 +51,7 @@ class SearchedItemsViewController:UIViewController, UISearchBarDelegate, UITable
         setupSearchBarDelegate()
     }
     
-    ///親VC(SearchViewController)の取得
+    /// 親VC(SearchViewController)の取得
     private func setupSearchBarDelegate() {
         // 親のViewControllerから検索バーを参照し、delegateとして自分を設定
         if let parentVC = self.parent as? SearchViewController {
@@ -59,7 +59,7 @@ class SearchedItemsViewController:UIViewController, UISearchBarDelegate, UITable
         }
     }
     
-    ///SearchBarに入力された文字を取得しモデルに渡す処理
+    /// SearchBarに入力された文字を取得しモデルに渡す処理
     func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
         guard let searchText = searchBar.text else {
             return

--- a/rakuten_ranking_app/Views/SearchedItemsViewController.swift
+++ b/rakuten_ranking_app/Views/SearchedItemsViewController.swift
@@ -20,19 +20,14 @@ class SearchedItemsViewController:UIViewController, UISearchBarDelegate, UITable
     
     @IBOutlet weak var tableView: UITableView!
     
-    private var items: [SearchItemElement] = []
-    
     deinit {
         model?.notificationCenter.removeObserver(self)
     }
     
     private func registerModel() {
-        _ = model?.notificationCenter.addObserver(forName: .init(rawValue: NotificationConst.searchNotificationName),
-                                                  object: nil, queue: nil) { [weak self] notification in
-            if let search = notification.userInfo?[NotificationConst.UserInfoKeysForSearch.search] as? Search {
-                self?.items = search.items
-                self?.tableView.reloadData()
-            }
+        model?.notificationCenter.addObserver(forName: .init(rawValue: NotificationConst.searchNotificationName),
+                                                object: nil, queue: OperationQueue.main) { [weak self] _ in
+            self?.tableView.reloadData()
         }
     }
     
@@ -70,14 +65,16 @@ class SearchedItemsViewController:UIViewController, UISearchBarDelegate, UITable
 
 extension SearchedItemsViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return items.count
+        return model?.search?.items.count ?? 0
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "SearchCell", for: indexPath) as! SearchTableViewCell
-        let item = items[indexPath.row].item
+        guard let item = model?.search?.items[indexPath.row] else {
+            fatalError("データを取得できませんでした。")
+        }
         
-        cell.configure(with: item, at: indexPath, in: tableView)
+        cell.configure(with: item.item, at: indexPath, in: tableView)
         
         return cell
     }

--- a/rakuten_ranking_app/Views/SearchedItemsViewController.swift
+++ b/rakuten_ranking_app/Views/SearchedItemsViewController.swift
@@ -7,21 +7,21 @@
 
 import UIKit
 
-class SearchedItemsViewController: UIViewController, UISearchBarDelegate, UITableViewDataSource, UITableViewDelegate {
+class SearchedItemsViewController: UIViewController, UISearchBarDelegate {
     
     // 検索文字列を保持するプロパティ
     var searchString: String?
-    var searchModel = SearchModel()
-    var tableView: UITableView!
+    var searchModel = SearchModel(apiClient: DefaultAPIClient.shared)
+    @IBOutlet weak var tableView: UITableView!
+    
+    private var items: [SearchItemElement] = []
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        setupTableView()
     }
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        setupSearchBarDelegate()
     }
     
     ///親VC(SearchViewController)の取得
@@ -41,24 +41,4 @@ class SearchedItemsViewController: UIViewController, UISearchBarDelegate, UITabl
         searchModel.fetchSearchResults(with: searchText)
     }
     
-    private func setupTableView() {
-        tableView = UITableView(frame: view.bounds, style: .plain)
-        tableView.delegate = self
-        tableView.dataSource = self
-        tableView.register(UINib(nibName: "SearchTableViewCell", bundle: nil), forCellReuseIdentifier: "SearchCell")
-        view.addSubview(tableView)
-    }
-    
-    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return searchModel.search?.items.count ?? 0
-    }
-    
-    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: "SearchCell", for: indexPath) as? SearchTableViewCell,
-              let item = searchModel.search?.items[indexPath.row].item else {
-            return UITableViewCell()
-        }
-        cell.configure(with: item, at: indexPath, in: tableView)
-        return cell
-    }
 }

--- a/rakuten_ranking_app/Views/SearchedItemsViewController.swift
+++ b/rakuten_ranking_app/Views/SearchedItemsViewController.swift
@@ -7,13 +7,18 @@
 
 import UIKit
 
-class SearchedItemsViewController: UIViewController, UISearchBarDelegate {
+class SearchedItemsViewController: UIViewController, UISearchBarDelegate, UITableViewDataSource, UITableViewDelegate {
     
     // 検索文字列を保持するプロパティ
     var searchString: String?
     var searchModel = SearchModel()
+    var tableView: UITableView!
     
-
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupTableView()
+    }
+    
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         setupSearchBarDelegate()
@@ -34,5 +39,26 @@ class SearchedItemsViewController: UIViewController, UISearchBarDelegate {
         }
         print("検索バーに入力された文字: \(searchText)")
         searchModel.fetchSearchResults(with: searchText)
+    }
+    
+    private func setupTableView() {
+        tableView = UITableView(frame: view.bounds, style: .plain)
+        tableView.delegate = self
+        tableView.dataSource = self
+        tableView.register(UINib(nibName: "SearchTableViewCell", bundle: nil), forCellReuseIdentifier: "SearchCell")
+        view.addSubview(tableView)
+    }
+    
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return searchModel.search?.items.count ?? 0
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: "SearchCell", for: indexPath) as? SearchTableViewCell,
+              let item = searchModel.search?.items[indexPath.row].item else {
+            return UITableViewCell()
+        }
+        cell.configure(with: item, at: indexPath, in: tableView)
+        return cell
     }
 }


### PR DESCRIPTION
# 背景　
## 何画面の画面なのか
商品検索画面

## どんな機能なのか
サーチバーで文字を入力し、それを元に商品を検索

# 資料リンク
[タスク14](https://docs.google.com/spreadsheets/d/1aR2vFXke8Flvqsfle_i8TpZvgoQ3dHUt-8LJdtDSm0s/edit#gid=0)

# 実装内容
## どんな実装にした

[SearchedViewController]
・SearchBarに入力された文字を取得しモデルに渡す
・NotificationCenterを使用して検索結果通知を購読し、検索結果が更新されたときにテーブルビューをリロード
・検索結果に基づいてセルを構成

[SearchModel]
・SearchedViewControllerから検索された文字を受け取りそれを引数にAPIを叩く
・変更があるたびにNotificationCenterを通じてSearchedViewControllerに通知

[SearchTableViewCell]
・特定の商品データを受け取り、それを元にセルのUIを更新


# レビューしてほしいところ
想定通りの挙動ができているかどうか


# 別のPRで対応すること
なし


# コンフリクト解消に関して
print文を最新のfeature/get_APIResultでは削除しましたがdevelopにはそれらが残っていたためコンフリクトが生じました。
どれも不要なprint文であったため、feature/get_APIResultを優先し解消しました。



