### PR TITLE
検索ボタンが押されたとき、画面上の任意の場所をタップしたときにキーボードを閉じる処理実装

### DIFF
--- a/rakuten_ranking_app.xcodeproj/project.pbxproj
+++ b/rakuten_ranking_app.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		6DAFB3F32BFC69E20092F9BC /* ImageFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DAFB3F22BFC69E20092F9BC /* ImageFetcher.swift */; };
 		6DC1933B2C05738F00FFD1AD /* SearchTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DC1933A2C05738F00FFD1AD /* SearchTableViewCell.swift */; };
 		6DF22AA62C07281E001B0654 /* SearchAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DF22AA52C07281E001B0654 /* SearchAPI.swift */; };
+		6DF22AAC2C09A9D8001B0654 /* DismissKeyboardTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DF22AAB2C09A9D8001B0654 /* DismissKeyboardTableView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -95,6 +96,7 @@
 		6DAFB3F22BFC69E20092F9BC /* ImageFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageFetcher.swift; sourceTree = "<group>"; };
 		6DC1933A2C05738F00FFD1AD /* SearchTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchTableViewCell.swift; sourceTree = "<group>"; };
 		6DF22AA52C07281E001B0654 /* SearchAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchAPI.swift; sourceTree = "<group>"; };
+		6DF22AAB2C09A9D8001B0654 /* DismissKeyboardTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DismissKeyboardTableView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -203,6 +205,7 @@
 				6DAFB3EC2BF753E30092F9BC /* RankingTableViewCell.swift */,
 				6D5245672C00854E0045289D /* SearchedItemsViewController.swift */,
 				6DC1933A2C05738F00FFD1AD /* SearchTableViewCell.swift */,
+				6DF22AAB2C09A9D8001B0654 /* DismissKeyboardTableView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -418,6 +421,7 @@
 				6D6782562BF2107000423201 /* APIClient.swift in Sources */,
 				6DAFB3F12BFC69D30092F9BC /* PriceFormatter.swift in Sources */,
 				6D6782672BF4A6CF00423201 /* Constants.swift in Sources */,
+				6DF22AAC2C09A9D8001B0654 /* DismissKeyboardTableView.swift in Sources */,
 				6D6782132BEC69DB00423201 /* RankingForAllViewController.swift in Sources */,
 				6DF22AA62C07281E001B0654 /* SearchAPI.swift in Sources */,
 				6D5245642C0073A90045289D /* Search.swift in Sources */,

--- a/rakuten_ranking_app.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/rakuten_ranking_app.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "4fbec9efde6a900cf2a498554b39c27b126a9330fb0a5649b008df65705ad0cd",
+  "originHash" : "218648fae3d95dcfb05f12fcd9eeea777dad443ae0d8edb1fd9e502211ee98e8",
   "pins" : [
     {
       "identity" : "alamofire",

--- a/rakuten_ranking_app/Base.lproj/Main.storyboard
+++ b/rakuten_ranking_app/Base.lproj/Main.storyboard
@@ -590,7 +590,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="393" height="666"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="gzB-tx-gHm">
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="gzB-tx-gHm" customClass="DismissKeyboardTableView" customModule="rakuten_ranking_app" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="59" width="393" height="573"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <prototypes>
@@ -687,7 +687,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="pbI-OF-t4o" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="11182.442748091602" y="261.97183098591552"/>
+            <point key="canvasLocation" x="11164" y="262"/>
         </scene>
     </scenes>
     <resources>

--- a/rakuten_ranking_app/Base.lproj/Main.storyboard
+++ b/rakuten_ranking_app/Base.lproj/Main.storyboard
@@ -673,6 +673,7 @@
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="Sib-kk-b0p"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <gestureRecognizers/>
                         <constraints>
                             <constraint firstItem="gzB-tx-gHm" firstAttribute="leading" secondItem="Sib-kk-b0p" secondAttribute="leading" id="L2P-h7-m2A"/>
                             <constraint firstItem="Sib-kk-b0p" firstAttribute="trailing" secondItem="gzB-tx-gHm" secondAttribute="trailing" id="QPs-zW-DY5"/>

--- a/rakuten_ranking_app/Views/DismissKeyboardTableView.swift
+++ b/rakuten_ranking_app/Views/DismissKeyboardTableView.swift
@@ -1,0 +1,14 @@
+//
+//  CustomTableView.swift
+//  rakuten_ranking_app
+//
+//  Created by 櫻田龍之助 on 2024/05/31.
+//
+
+import UIKit
+
+class DismissKeyboardTableView: UITableView {
+    override open func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        self.next?.touchesBegan(touches, with: event)
+    }
+}

--- a/rakuten_ranking_app/Views/SearchViewController.swift
+++ b/rakuten_ranking_app/Views/SearchViewController.swift
@@ -18,7 +18,6 @@ class SearchViewController: UIViewController,UISearchBarDelegate  {
         super.viewDidLoad()
         setupSearchBar()
         addEllipsisButton()
-        hideKeyboardWhenTappedAround()
     }
     
     /// searchBarをNavigationBarに設置する関数
@@ -52,15 +51,9 @@ class SearchViewController: UIViewController,UISearchBarDelegate  {
         print("elliipsがタップされました")
     }
     
-    /// 画面上の任意の場所をタップしたときにキーボードを閉じるためのタップジェスチャーを設定
-    func hideKeyboardWhenTappedAround() {
-        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
-        tapGesture.cancelsTouchesInView = false
-        view.addGestureRecognizer(tapGesture)
-    }
-    
-    @objc func dismissKeyboard() {
-        view.endEditing(true)
+    /// タップイベントを検知し、キーボードを閉じる処理
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        self.view.endEditing(true)
     }
     
     /// 検索ボタンが押されたときにキーボードを閉じる

--- a/rakuten_ranking_app/Views/SearchViewController.swift
+++ b/rakuten_ranking_app/Views/SearchViewController.swift
@@ -24,7 +24,6 @@ class SearchViewController: UIViewController,UISearchBarDelegate  {
     func setupSearchBar() {
         if let navigationBarFrame = navigationController?.navigationBar.bounds {
             let searchBar = UISearchBar(frame: navigationBarFrame)
-            searchBar.delegate = self
             searchBar.placeholder = "商品を検索"
             searchBar.tintColor = UIColor.gray
             searchBar.keyboardType = .default
@@ -49,10 +48,5 @@ class SearchViewController: UIViewController,UISearchBarDelegate  {
     
     @objc func ellipsisButtonTapped() {
         print("elliipsがタップされました")
-    }
-    
-    /// 検索ボタンが押されたときにキーボードを閉じる
-    func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
-        searchBar.resignFirstResponder()
     }
 }

--- a/rakuten_ranking_app/Views/SearchViewController.swift
+++ b/rakuten_ranking_app/Views/SearchViewController.swift
@@ -18,6 +18,7 @@ class SearchViewController: UIViewController,UISearchBarDelegate  {
         super.viewDidLoad()
         setupSearchBar()
         addEllipsisButton()
+        hideKeyboardWhenTappedAround()
     }
     
     /// searchBarをNavigationBarに設置する関数
@@ -49,5 +50,21 @@ class SearchViewController: UIViewController,UISearchBarDelegate  {
     
     @objc func ellipsisButtonTapped() {
         print("elliipsがタップされました")
+    }
+    
+    /// 画面上の任意の場所をタップしたときにキーボードを閉じるためのタップジェスチャーを設定
+    func hideKeyboardWhenTappedAround() {
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
+        tapGesture.cancelsTouchesInView = false
+        view.addGestureRecognizer(tapGesture)
+    }
+    
+    @objc func dismissKeyboard() {
+        view.endEditing(true)
+    }
+    
+    /// 検索ボタンが押されたときにキーボードを閉じる
+    func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
+        searchBar.resignFirstResponder()
     }
 }

--- a/rakuten_ranking_app/Views/SearchViewController.swift
+++ b/rakuten_ranking_app/Views/SearchViewController.swift
@@ -51,11 +51,6 @@ class SearchViewController: UIViewController,UISearchBarDelegate  {
         print("elliipsがタップされました")
     }
     
-    /// タップイベントを検知し、キーボードを閉じる処理
-    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
-        self.view.endEditing(true)
-    }
-    
     /// 検索ボタンが押されたときにキーボードを閉じる
     func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
         searchBar.resignFirstResponder()

--- a/rakuten_ranking_app/Views/SearchViewController.swift
+++ b/rakuten_ranking_app/Views/SearchViewController.swift
@@ -9,7 +9,7 @@ import UIKit
 import SVGKit
 
 
-class SearchViewController: UIViewController,UISearchBarDelegate  {
+class SearchViewController: UIViewController  {
     
     @IBOutlet weak var searchBar: UISearchBar!
     @IBOutlet weak var ellipsis: UIImageView!

--- a/rakuten_ranking_app/Views/SearchedItemsViewController.swift
+++ b/rakuten_ranking_app/Views/SearchedItemsViewController.swift
@@ -61,7 +61,7 @@ class SearchedItemsViewController:UIViewController, UISearchBarDelegate, UITable
     
     /// タップイベントを検知し、キーボードを閉じる処理
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
-         self.view.endEditing(true)
+        self.parentSearchBar?.endEditing(true)
     }
     
     /// SearchBarに入力された文字を取得しモデルに渡す処理

--- a/rakuten_ranking_app/Views/SearchedItemsViewController.swift
+++ b/rakuten_ranking_app/Views/SearchedItemsViewController.swift
@@ -18,6 +18,9 @@ class SearchedItemsViewController:UIViewController, UISearchBarDelegate, UITable
         }
     }
     
+    // 親の検索バーを取得
+    var parentSearchBar: UISearchBar?
+    
     @IBOutlet weak var tableView: UITableView!
     
     deinit {
@@ -26,7 +29,7 @@ class SearchedItemsViewController:UIViewController, UISearchBarDelegate, UITable
     
     private func registerModel() {
         model?.notificationCenter.addObserver(forName: .init(rawValue: NotificationConst.searchNotificationName),
-                                                object: nil, queue: OperationQueue.main) { [weak self] _ in
+                                              object: nil, queue: OperationQueue.main) { [weak self] _ in
             self?.tableView.reloadData()
         }
     }
@@ -37,6 +40,7 @@ class SearchedItemsViewController:UIViewController, UISearchBarDelegate, UITable
         tableView.dataSource = self
         tableView.delegate = self
         tableView.separatorStyle = .none
+        tableView.keyboardDismissMode = .onDrag
         
         model = SearchModel(apiClient: DefaultAPIClient.shared)
     }
@@ -51,6 +55,7 @@ class SearchedItemsViewController:UIViewController, UISearchBarDelegate, UITable
         // 親のViewControllerから検索バーを参照し、delegateとして自分を設定
         if let parentVC = self.parent as? SearchViewController {
             parentVC.searchBar.delegate = self
+            parentSearchBar = parentVC.searchBar
         }
     }
     
@@ -60,6 +65,7 @@ class SearchedItemsViewController:UIViewController, UISearchBarDelegate, UITable
             return
         }
         model?.fetchSearchResults(with: searchText)
+        searchBar.resignFirstResponder()
     }
 }
 
@@ -79,5 +85,3 @@ extension SearchedItemsViewController: UITableViewDataSource {
         return cell
     }
 }
-
-

--- a/rakuten_ranking_app/Views/SearchedItemsViewController.swift
+++ b/rakuten_ranking_app/Views/SearchedItemsViewController.swift
@@ -59,6 +59,11 @@ class SearchedItemsViewController:UIViewController, UISearchBarDelegate, UITable
         }
     }
     
+    /// タップイベントを検知し、キーボードを閉じる処理
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+         self.view.endEditing(true)
+    }
+    
     /// SearchBarに入力された文字を取得しモデルに渡す処理
     func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
         guard let searchText = searchBar.text else {


### PR DESCRIPTION
# 背景
## 何画面の画面なのか
商品検索画面

## どんな機能なのか
商品を検索できる機能

# 資料リンク
[参考資料](https://stackoverflow.com/questions/29925373/how-to-make-keyboard-dismiss-when-i-press-out-of-searchbar-on-swift)

# 実装内容
## どんな実装にした
検索ボタンが押されたときや画面上の任意の場所をタップしたときにキーボードを閉じる処理を実装

https://github.com/skrdron/rakuten_ranking_app/assets/165979825/8176db9d-1a6a-4db5-bce0-f2da07f72f74


# レビューしてほしいところ
想定通りの実装になっているかどうか

以下の警告が出ているが、調べたところapple iOSの問題らしいのですがこれを放置してもいいのかどうか
[警告]
-[RTIInputSystemClient remoteTextInputSessionWithID:performInputOperation:]  perform input operation requires a valid sessionID. inputModality = Keyboard, inputOperation = <null selector>, customInfoType = UIEmojiSearchOperations

[参考資料](https://stackoverflow.com/questions/77800488/rtiinputsystemclient-remotetextinputsessionwithidperforminputoperation-perf)


# 別のPRで対応すること
・何も検索していない時にテキストを表示させる実装
・検索後、タブをランキング/検索/ブックマークの様に遷移させた時に検索結果をクリアにした方が良さそうと思ったのでその実装
