### PR TITLE
初期画面のラベル表示

### DIFF
--- a/rakuten_ranking_app/Base.lproj/Main.storyboard
+++ b/rakuten_ranking_app/Base.lproj/Main.storyboard
@@ -670,18 +670,27 @@
                                     </tableViewCell>
                                 </prototypes>
                             </tableView>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="uyt-Wj-xck">
+                                <rect key="frame" x="175.66666666666666" y="322.66666666666669" width="42" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="Sib-kk-b0p"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <gestureRecognizers/>
                         <constraints>
+                            <constraint firstItem="uyt-Wj-xck" firstAttribute="centerX" secondItem="f24-Ty-sLP" secondAttribute="centerX" id="D6o-AQ-Fau"/>
                             <constraint firstItem="gzB-tx-gHm" firstAttribute="leading" secondItem="Sib-kk-b0p" secondAttribute="leading" id="L2P-h7-m2A"/>
                             <constraint firstItem="Sib-kk-b0p" firstAttribute="trailing" secondItem="gzB-tx-gHm" secondAttribute="trailing" id="QPs-zW-DY5"/>
                             <constraint firstItem="gzB-tx-gHm" firstAttribute="top" secondItem="Sib-kk-b0p" secondAttribute="top" id="VEl-X3-OV2"/>
+                            <constraint firstItem="uyt-Wj-xck" firstAttribute="centerY" secondItem="f24-Ty-sLP" secondAttribute="centerY" id="Vn4-7U-7xp"/>
                             <constraint firstItem="Sib-kk-b0p" firstAttribute="bottom" secondItem="gzB-tx-gHm" secondAttribute="bottom" id="jks-yj-p7F"/>
                         </constraints>
                     </view>
                     <connections>
+                        <outlet property="emptyLabel" destination="uyt-Wj-xck" id="cfP-V3-fUv"/>
                         <outlet property="tableView" destination="gzB-tx-gHm" id="8OL-JO-SoB"/>
                     </connections>
                 </viewController>

--- a/rakuten_ranking_app/Views/SearchViewController.swift
+++ b/rakuten_ranking_app/Views/SearchViewController.swift
@@ -18,7 +18,6 @@ class SearchViewController: UIViewController,UISearchBarDelegate  {
         super.viewDidLoad()
         setupSearchBar()
         addEllipsisButton()
-        hideKeyboardWhenTappedAround()
     }
     
     /// searchBarをNavigationBarに設置する関数
@@ -52,15 +51,9 @@ class SearchViewController: UIViewController,UISearchBarDelegate  {
         print("elliipsがタップされました")
     }
     
-    /// 画面上の任意の場所をタップしたときにキーボードを閉じるためのタップジェスチャーを設定
-    func hideKeyboardWhenTappedAround() {
-        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
-        tapGesture.cancelsTouchesInView = false
-        view.addGestureRecognizer(tapGesture)
-    }
-    
-    @objc func dismissKeyboard() {
-        view.endEditing(true)
+    /// タップイベントを検知し、キーボードを閉じる処理
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        self.view.endEditing(true)
     }
     
     /// 検索ボタンが押されたときにキーボードを閉じる

--- a/rakuten_ranking_app/Views/SearchedItemsViewController.swift
+++ b/rakuten_ranking_app/Views/SearchedItemsViewController.swift
@@ -21,6 +21,7 @@ class SearchedItemsViewController:UIViewController, UISearchBarDelegate, UITable
     // 親の検索バーを取得
     var parentSearchBar: UISearchBar?
     
+    @IBOutlet weak var emptyLabel: UILabel!
     @IBOutlet weak var tableView: UITableView!
     
     deinit {
@@ -31,6 +32,7 @@ class SearchedItemsViewController:UIViewController, UISearchBarDelegate, UITable
         model?.notificationCenter.addObserver(forName: .init(rawValue: NotificationConst.searchNotificationName),
                                               object: nil, queue: OperationQueue.main) { [weak self] _ in
             self?.tableView.reloadData()
+            self?.updateEmptyLabelVisibility()
         }
     }
     
@@ -43,6 +45,9 @@ class SearchedItemsViewController:UIViewController, UISearchBarDelegate, UITable
         tableView.keyboardDismissMode = .onDrag
         
         model = SearchModel(apiClient: DefaultAPIClient.shared)
+        
+        emptyLabel.text = "商品がありません"
+        emptyLabel.tintColor = UIColor.gray
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -59,6 +64,10 @@ class SearchedItemsViewController:UIViewController, UISearchBarDelegate, UITable
         }
     }
     
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        self.view.endEditing(true)
+    }
+    
     /// SearchBarに入力された文字を取得しモデルに渡す処理
     func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
         guard let searchText = searchBar.text else {
@@ -67,11 +76,17 @@ class SearchedItemsViewController:UIViewController, UISearchBarDelegate, UITable
         model?.fetchSearchResults(with: searchText)
         searchBar.resignFirstResponder()
     }
+    
+    private func updateEmptyLabelVisibility() {
+        let itemCount = model?.search?.items.count ?? 0
+        emptyLabel.isHidden = itemCount > 0
+    }
 }
 
 extension SearchedItemsViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return model?.search?.items.count ?? 0
+        let count = model?.search?.items.count ?? 0
+        return count
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {


### PR DESCRIPTION
# 背景
## 何画面の画面なのか
商品検索画面

## どんな機能なのか
初期画面が真っ白になっていたので、初期画面と検索した商品がない場合”商品がありません”というラベルを出現させる

# 資料リンク
[タスク12](https://docs.google.com/spreadsheets/d/1aR2vFXke8Flvqsfle_i8TpZvgoQ3dHUt-8LJdtDSm0s/edit#gid=0)

# 実装内容
## どんな実装にした
ラベルを設置し、商品の数(item.count)が0であるかどうかを場合分けして表示を制御している

# レビューしてほしいところ
想定通りの挙動をきちんとしているかどうか

# 別のPRで対応すること
タブ切り替え時とサーチバーを空欄にした時の検索結果のクリア

